### PR TITLE
install-yaraX.sh fix

### DIFF
--- a/yara/install-yara2.sh
+++ b/yara/install-yara2.sh
@@ -20,7 +20,7 @@ cd yara2.git || exit 1
 # working yara2 version
 git reset --hard 880c268ce0b98046a476784c412d9e91573c8a08
 sh bootstrap.sh
-./configure --prefix=${PREFIX} || exit 1
+../configure --prefix=${PREFIX} || exit 1
 ${MAKE} -j8 CFLAGS=-DYYDEBUG=0 || exit 1
 ${SUDO} ${MAKE} install
 

--- a/yara/install-yara3.sh
+++ b/yara/install-yara3.sh
@@ -20,6 +20,6 @@ cd yara3.git || exit 1
 # last commit in git
 git pull
 sh bootstrap.sh
-./configure --prefix=${PREFIX} || exit 1
+../configure --prefix=${PREFIX} || exit 1
 ${MAKE} -j8 || exit 1
 ${SUDO} ${MAKE} install


### PR DESCRIPTION
Went through the recommended install on http://www.radare.org/r/down.html and ran into an error, which aborts the install-yara3.sh script because of a wrong path of the configure files.

In install-yara2.sh is the same error, but I only installed v3.