### PR TITLE
Fix Minidump sections

### DIFF
--- a/libr/bin/format/mdmp/mdmp.c
+++ b/libr/bin/format/mdmp/mdmp.c
@@ -235,12 +235,12 @@ int r_bin_mdmp_init_directory(struct r_bin_mdmp_obj *obj, PMINIDUMP_DIRECTORY di
 			p = obj->b->buf + dir->Location.Rva;
 			j = ((PMINIDUMP_MODULE_LIST)p)->NumberOfModules;
 			for (i = 0; i < j; i++) {
-				p = (void *)(&((PMINIDUMP_MODULE_LIST)p)->Modules[i]);
-				if (p - (void *)obj->b->buf + sizeof(MINIDUMP_MODULE) > obj->b->length) {
+				m = (void *)(&((PMINIDUMP_MODULE_LIST)p)->Modules[i]);
+				if (m - (void *)obj->b->buf + sizeof(MINIDUMP_MODULE) > obj->b->length) {
 					eprintf("Warning in r_bin_mdmp_init_directory: length too short, not enough space for all MINIDUMP_MODULE\n");
 					break;
 				}
-				r_list_append(obj->modules, p);
+				r_list_append(obj->modules, m);
 			};
 		};
 		break;
@@ -267,12 +267,12 @@ int r_bin_mdmp_init_directory(struct r_bin_mdmp_obj *obj, PMINIDUMP_DIRECTORY di
 			p = obj->b->buf + dir->Location.Rva;
 			j = ((PMINIDUMP_MEMORY64_LIST)p)->NumberOfMemoryRanges;
 			for (i = 0; i < j; i++) {
-				p = (void *)(&((PMINIDUMP_MEMORY64_LIST)p)->MemoryRanges[i]);
-				if (p - (void *)obj->b->buf + sizeof(MINIDUMP_MEMORY_DESCRIPTOR64) > obj->b->length) {
+				m = (void *)(&((PMINIDUMP_MEMORY64_LIST)p)->MemoryRanges[i]);
+				if (m - (void *)obj->b->buf + sizeof(MINIDUMP_MEMORY_DESCRIPTOR64) > obj->b->length) {
 					eprintf("Warning in r_bin_mdmp_init_directory: length too short, not enough space for all MINIDUMP_MEMORY_DESCRIPTOR64\n");
 					break;
 				}
-				r_list_append(obj->memory64, p);
+				r_list_append(obj->memory64, m);
 			};
 		};
 		break;
@@ -365,7 +365,7 @@ int r_bin_mdmp_init_directory(struct r_bin_mdmp_obj *obj, PMINIDUMP_DIRECTORY di
 }
 
 PMINIDUMP_STRING r_bin_mdmp_locate_string(struct r_bin_mdmp_obj *obj, RVA Rva) {
-	if (Rva < obj->b->length)
+	if (Rva >= obj->b->length)
 		return NULL;
 	return (PMINIDUMP_STRING)(obj->b->buf + Rva);
 }

--- a/libr/bin/format/mdmp/mdmp_specs.h
+++ b/libr/bin/format/mdmp/mdmp_specs.h
@@ -218,7 +218,7 @@ typedef struct MINIDUMP_EXCEPTION_STREAM {
 } MINIDUMP_EXCEPTION_STREAM, *PMINIDUMP_EXCEPTION_STREAM;
 
 
-typedef struct _MINIDUMP_MODULE {
+typedef struct __attribute__((__packed__)) _MINIDUMP_MODULE {
 	ut64 BaseOfImage;
 	ut32 SizeOfImage;
 	ut32 CheckSum;
@@ -231,7 +231,7 @@ typedef struct _MINIDUMP_MODULE {
 	ut64 Reserved1;
 } MINIDUMP_MODULE, *PMINIDUMP_MODULE;
 
-typedef struct _MINIDUMP_MODULE_LIST {
+typedef struct __attribute__((__packed__)) _MINIDUMP_MODULE_LIST {
 	ut32 NumberOfModules;
 	MINIDUMP_MODULE Modules [ 0 ];
 } MINIDUMP_MODULE_LIST, *PMINIDUMP_MODULE_LIST;

--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -64,6 +64,7 @@ static RList *sections(RBinFile *arch) {
 	struct r_bin_mdmp_obj *obj = arch->o->bin_obj;
 	PMINIDUMP_MODULE module;
 	PMINIDUMP_STRING str;
+	int i, j;
 
 	if (!(ret = r_list_newf(free)))
 		return NULL;
@@ -74,7 +75,9 @@ static RList *sections(RBinFile *arch) {
 			break;
 		}
 		if ((str = r_bin_mdmp_locate_string(obj, module->ModuleNameRva))) {
-			//strncpy(ptr->name, (char *)str->Buffer, R_MIN(str->Length, R_BIN_SIZEOF_STRINGS));
+			// FIX ME: HACK, need proper UTF-16 decoding
+			for (i = 0, j = R_MIN(str->Length, R_BIN_SIZEOF_STRINGS); i < j; i++)
+				ptr->name[i] = str->Buffer[i];
 		}
 		ptr->size = module->SizeOfImage;
 		ptr->vsize = module->SizeOfImage;


### PR DESCRIPTION
This PR fixes Minidump sections, module structs need to be packed otherwise compiler would insert padding and it wouldn't match file image.
Now module names (full file path) are stored but need proper UTF-16 parsing. Also fixed few other mistakes, I guess I was drunk when I wrote that as it could never have worked and didn't made any sense :D


now it looks like this
```
[0x00000000]> ia
[..]
[Sections]
idx=01 vaddr=0x77950000 paddr=0x00000fb8 sz=1572864 vsz=1572864 perm=----- name=C:_Windows_SysWOW64_ntdll.dll
idx=02 vaddr=0x75370000 paddr=0x00001024 sz=1114112 vsz=1114112 perm=----- name=C:_Windows_SysWOW64_kernel32.dll
[..]
```

Note that paddr doesn't actually point to code section but only to MINIDUMP_MODULE struct, it's all still very incomplete and sections are kinda abused here with module info because seems there aren't good place where to store this info.
