### PR TITLE
removed -lc++ flag from keystone Makefile

### DIFF
--- a/keystone/Makefile
+++ b/keystone/Makefile
@@ -13,7 +13,7 @@ all: $(PLUGINS)
 #$(info $(LIBS))
 
 define kscc
-$(CC) -lc++ -fPIC $(LDFLAGS_SHARED) -Wall\
+$(CC) -fPIC $(LDFLAGS_SHARED) -Wall\
 	$(R2_CFLAGS) $(R2_LDFLAGS)\
 	$(KS_CFLAGS) $(KS_LDFLAGS)\
 	-o asm_$(1)_ks.$(SO_EXT) asm_$(1)_ks.c $(KS_LINK)


### PR DESCRIPTION
fix #70
``-lc++`` stands for http://libcxx.llvm.org/ (c++ standard library) but I don't have this library. I have libstdc++ https://gcc.gnu.org/wiki/Libstdc++