### PR TITLE
fix keystone build

### DIFF
--- a/keystone/Makefile
+++ b/keystone/Makefile
@@ -13,10 +13,13 @@ all: $(PLUGINS)
 #$(info $(LIBS))
 
 define kscc
-$(CC) -lc++ -fPIC $(LDFLAGS_SHARED) -Wall\
-	$(R2_CFLAGS) $(R2_LDFLAGS)\
-	$(KS_CFLAGS) $(KS_LDFLAGS)\
-	-o asm_$(1)_ks.$(SO_EXT) asm_$(1)_ks.c $(KS_LINK)
+$(CC) -c -fPIC $(LDFLAGS_SHARED) -Wall\
+	$(R2_CFLAGS) $(KS_CFLAGS)\
+	-o asm_$(1)_ks.$(O_EXT) asm_$(1)_ks.c
+$(CXX)  $(LDFLAGS_SHARED) -Wall\
+	$(R2_LDFLAGS) $(KS_LDFLAGS)\
+	-o asm_$(1)_ks.$(SO_EXT) asm_$(1)_ks.$(O_EXT) $(KS_LINK)
+rm asm_$(1)_ks.$(O_EXT)
 endef
 
 define ksmake

--- a/keystone/Makefile
+++ b/keystone/Makefile
@@ -13,10 +13,10 @@ all: $(PLUGINS)
 #$(info $(LIBS))
 
 define kscc
-$(CC) -c -fPIC $(LDFLAGS_SHARED) -Wall\
+$(CC) -c -fPIC -Wall\
 	$(R2_CFLAGS) $(KS_CFLAGS)\
 	-o asm_$(1)_ks.$(O_EXT) asm_$(1)_ks.c
-$(CXX)  $(LDFLAGS_SHARED) -Wall\
+$(CXX) $(LDFLAGS_SHARED)\
 	$(R2_LDFLAGS) $(KS_LDFLAGS)\
 	-o asm_$(1)_ks.$(SO_EXT) asm_$(1)_ks.$(O_EXT) $(KS_LINK)
 rm asm_$(1)_ks.$(O_EXT)

--- a/keystone/build.mk
+++ b/keystone/build.mk
@@ -11,6 +11,7 @@ else
 SO_EXT=so
 endif
 endif
+O_EXT=o
 
 KS_CFLAGS=$(shell pkg-config --cflags keystone)
 KS_LDFLAGS=$(shell pkg-config --libs keystone)


### PR DESCRIPTION
fix #70 to get rid of libcxx