### PR TITLE
Make r2snow always exit with 0

### DIFF
--- a/r2snowman/r2snow
+++ b/r2snowman/r2snow
@@ -15,3 +15,4 @@ fi
 
 r2snow.bin $TARGET > /dev/null
 r2snow.pl
+exit 0


### PR DESCRIPTION
Sometimes r2snow returns proper r2 commands but still exits with non-0 return value causing r_sys_cmd_str_full: failed command 'r2snow'.
This dirty hack supresses this.