### PR TITLE
r2snow.pl: Fix reading source file into scalar

### DIFF
--- a/r2snowman/r2snow.pl
+++ b/r2snowman/r2snow.pl
@@ -21,7 +21,7 @@ use constant {
   R2SNOW_SOURCE => "r2snow-source.c"
 };
 
-my $source = rf(R2SNOW_SOURCE);
+my $source = join("", rf(R2SNOW_SOURCE));
 my @addrof = rf("r2snow-addrof.txt");
 
 my $ts = $source;


### PR DESCRIPTION
The rf function reads a file into an array context; however it is
assigned to the scalar $source below. On some (all?) versions of perl,
this scalar is then assigned the line count of the source file. Joining
the array solves this problem.