### PR TITLE
Fix Travis checks: r2snow dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ addons:
       - mono-xbuild
       - curl
       - tcc
+      - libboost-dev
+      - libqt4-dev
 
 env:
   - TESTS="r2pm -i armthumb"


### PR DESCRIPTION
The r2snow test fails with the following message: 

    ERROR: Build failed. You probably need 'brew install cartr/qt4/qt' and 'brew install boost' or 'sudo apt-get install libboost-dev libqt4-dev'

Adding these should make the build succeed again.