### PR TITLE
MDMP - Applied fixes due to changes in the core

### DIFF
--- a/libr/bin/format/mdmp/mdmp.c
+++ b/libr/bin/format/mdmp/mdmp.c
@@ -744,7 +744,7 @@ static bool r_bin_mdmp_init_pe_bins(struct r_bin_mdmp_obj *obj) {
 			r_bin_mdmp_patch_pe_headers (buf);
 			pe32_bin->vaddr = module->base_of_image;
 			pe32_bin->paddr = paddr;
-			pe32_bin->bin = Pe32_r_bin_pe_new_buf (buf);
+			pe32_bin->bin = Pe32_r_bin_pe_new_buf (buf, 0);
 
 			r_list_append (obj->pe32_bins, pe32_bin);
 		} else if (check_pe64_bytes (buf->buf, module->size_of_image)) {
@@ -761,7 +761,7 @@ static bool r_bin_mdmp_init_pe_bins(struct r_bin_mdmp_obj *obj) {
 			r_bin_mdmp_patch_pe_headers (buf);
 			pe64_bin->vaddr = module->base_of_image;
 			pe64_bin->paddr = paddr;
-			pe64_bin->bin = Pe64_r_bin_pe_new_buf (buf);
+			pe64_bin->bin = Pe64_r_bin_pe_new_buf (buf, 0);
 
 			r_list_append (obj->pe64_bins, pe64_bin);
 		}

--- a/libr/bin/format/mdmp/mdmp_pe.c
+++ b/libr/bin/format/mdmp/mdmp_pe.c
@@ -8,7 +8,7 @@
 static void PE_(add_tls_callbacks)(struct PE_(r_bin_pe_obj_t) *bin, RList* list) {
 	char *key;
 	int count = 0;
-	PE_DWord paddr, vaddr;
+	PE_DWord haddr, paddr, vaddr;
 	RBinAddr *ptr = NULL;
 
 	do {
@@ -23,9 +23,16 @@ static void PE_(add_tls_callbacks)(struct PE_(r_bin_pe_obj_t) *bin, RList* list)
 		if (!vaddr) {
 			break;
 		}
+
+		key =  sdb_fmt (0, "pe.tls_callback%d_haddr", count);
+		haddr = sdb_num_get (bin->kv, key, 0);
+		if (!haddr) {
+			break;
+		}
 		if ((ptr = R_NEW0 (RBinAddr))) {
 			ptr->paddr = paddr;
 			ptr->vaddr = vaddr;
+			ptr->haddr = haddr;
 			ptr->type  = R_BIN_ENTRY_TYPE_TLS;
 			r_list_append (list, ptr);
 		}
@@ -53,6 +60,7 @@ RList *PE_(r_bin_mdmp_pe_get_entrypoint)(struct PE_(r_bin_mdmp_pe_bin) *pe_bin) 
 		}
 		ptr->paddr = offset + pe_bin->paddr;
 		ptr->vaddr = offset + pe_bin->vaddr;
+		ptr->haddr = pe_bin->paddr + entry->haddr;
 		ptr->type  = R_BIN_ENTRY_TYPE_PROGRAM;
 
 		r_list_append (ret, ptr);
@@ -185,7 +193,7 @@ RList *PE_(r_bin_mdmp_pe_get_sections)(struct PE_(r_bin_mdmp_pe_bin) *pe_bin) {
 #define ROW (4 | 2)
 		if (ptr->srwx & ROW && !(ptr->srwx & X) && ptr->size > 0) {
 			if (!strcmp (ptr->name, ".rsrc") ||
-			  	!strcmp (ptr->name, ".data") ||
+				!strcmp (ptr->name, ".data") ||
 				!strcmp (ptr->name, ".rdata")) {
 					ptr->is_data = true;
 				}

--- a/libr/bin/format/mdmp/pe/pe.h
+++ b/libr/bin/format/mdmp/pe/pe.h
@@ -17,6 +17,7 @@
 struct r_bin_pe_addr_t {
 	ut64 vaddr;
 	ut64 paddr;
+	ut64 haddr;
 };
 
 struct r_bin_pe_section_t {
@@ -74,7 +75,7 @@ typedef struct SDebugInfo{
 struct PE_(r_bin_pe_obj_t) {
 	// these pointers contain a copy of the headers and sections!
 	PE_(image_dos_header)             *dos_header;
-	PE_(image_nt_headers)		  *nt_headers;
+	PE_(image_nt_headers)             *nt_headers;
 	PE_(image_optional_header)        *optional_header; //not free this just pointer into nt_headers
 	PE_(image_data_directory)         *data_directory;  //not free this just pointer into nt_headers
 	PE_(image_section_header)         *section_header;
@@ -94,6 +95,7 @@ struct PE_(r_bin_pe_obj_t) {
 	int size;
 	int num_sections;
 	int endian;
+	bool verbose;
 	RList *relocs;
 	const char* file;
 	struct r_buf_t* b;
@@ -124,8 +126,8 @@ int PE_(r_bin_pe_is_stripped_line_nums)(struct PE_(r_bin_pe_obj_t)* bin);
 int PE_(r_bin_pe_is_stripped_local_syms)(struct PE_(r_bin_pe_obj_t)* bin);
 int PE_(r_bin_pe_is_stripped_debug)(struct PE_(r_bin_pe_obj_t)* bin);
 void* PE_(r_bin_pe_free)(struct PE_(r_bin_pe_obj_t)* bin);
-struct PE_(r_bin_pe_obj_t)* PE_(r_bin_pe_new)(const char* file);
-struct PE_(r_bin_pe_obj_t)* PE_(r_bin_pe_new_buf)(struct r_buf_t *buf);
+struct PE_(r_bin_pe_obj_t)* PE_(r_bin_pe_new)(const char* file, bool verbose);
+struct PE_(r_bin_pe_obj_t)* PE_(r_bin_pe_new_buf)(struct r_buf_t *buf, bool verbose);
 int PE_(r_bin_pe_get_debug_data)(struct PE_(r_bin_pe_obj_t) *bin, struct SDebugInfo *res);
 int PE_(bin_pe_get_claimed_checksum)(struct PE_(r_bin_pe_obj_t) *bin);
 int PE_(bin_pe_get_actual_checksum)(struct PE_(r_bin_pe_obj_t) *bin);

--- a/libr/bin/format/mdmp/pe/pe_specs.h
+++ b/libr/bin/format/mdmp/pe/pe_specs.h
@@ -60,6 +60,7 @@ typedef struct {
 #define PE_IMAGE_FILE_MACHINE_AM33             0x01d3
 #define PE_IMAGE_FILE_MACHINE_AMD64            0x8664
 #define PE_IMAGE_FILE_MACHINE_ARM              0x01c0
+#define PE_IMAGE_FILE_MACHINE_ARM64            0xaa64
 #define PE_IMAGE_FILE_MACHINE_AXP64            PE_IMAGE_FILE_MACHINE_ALPHA64
 #define PE_IMAGE_FILE_MACHINE_CEE              0xc0ee
 #define PE_IMAGE_FILE_MACHINE_CEF              0x0cef

--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -7,28 +7,6 @@
 
 #include "mdmp/mdmp.h"
 
-/* TODO: This is a correct implementation for r_llist_join, I will create a PR
- * on the core for this! */
-static int r_llist_join(RList *list1, RList *list2) {
-	if (!list1 || !list2) return 0;
-	if (!(list2->length)) return 0;
-
-	if (!(list1->length)) {
-		list1->head = list2->head;
-		list1->tail = list2->tail;
-	} else {
-		list1->tail->n = list2->head;
-		list2->head->p = list1->tail;
-		list1->tail = list2->tail;
-		list1->tail->n = NULL;
-		list1->sorted = false;
-	}
-	list1->length += list2->length;
-	list2->head = list2->tail = NULL;
-	/* the caller must free list2 */
-	return 1;
-}
-
 /* FIXME: This is already in r_bin.c but its static, why?! */
 static void r_bbin_mem_free(void *data) {
 	RBinMem *mem = (RBinMem *)data;
@@ -77,12 +55,12 @@ static RList* entries(RBinFile *arch) {
 
 	r_list_foreach (obj->pe32_bins, it, pe32_bin) {
 		list = Pe32_r_bin_mdmp_pe_get_entrypoint (pe32_bin);
-		r_llist_join (ret, list);
+		r_list_join (ret, list);
 		r_list_free (list);
 	}
 	r_list_foreach (obj->pe64_bins, it, pe64_bin) {
 		list = Pe64_r_bin_mdmp_pe_get_entrypoint (pe64_bin);
-		r_llist_join (ret, list);
+		r_list_join (ret, list);
 		r_list_free (list);
 	}
 
@@ -317,14 +295,14 @@ static RList *sections(RBinFile *arch) {
 		r_list_foreach (obj->pe32_bins, it0, pe32_bin) {
 			if (pe32_bin->vaddr == module->base_of_image && pe32_bin->bin) {
 				pe_secs = Pe32_r_bin_mdmp_pe_get_sections(pe32_bin);
-				r_llist_join (ret, pe_secs);
+				r_list_join (ret, pe_secs);
 				r_list_free(pe_secs);
 			}
 		}
 		r_list_foreach (obj->pe64_bins, it0, pe64_bin) {
 			if (pe64_bin->vaddr == module->base_of_image && pe64_bin->bin) {
 				pe_secs = Pe64_r_bin_mdmp_pe_get_sections(pe64_bin);
-				r_llist_join (ret, pe_secs);
+				r_list_join (ret, pe_secs);
 				r_list_free(pe_secs);
 			}
 		}
@@ -419,12 +397,12 @@ static RList* relocs(RBinFile *arch) {
 
 	r_list_foreach (obj->pe32_bins, it, pe32_bin) {
 		if (pe32_bin->bin) {
-			r_llist_join (ret, pe32_bin->bin->relocs);
+			r_list_join (ret, pe32_bin->bin->relocs);
 		}
 	}
 	r_list_foreach (obj->pe64_bins, it, pe64_bin) {
 		if (pe64_bin->bin) {
-			r_llist_join (ret, pe64_bin->bin->relocs);
+			r_list_join (ret, pe64_bin->bin->relocs);
 		}
 	}
 
@@ -446,12 +424,12 @@ static RList* imports(RBinFile *arch) {
 
 	r_list_foreach (obj->pe32_bins, it, pe32_bin) {
 		list = Pe32_r_bin_mdmp_pe_get_imports (pe32_bin);
-		r_llist_join (ret, list);
+		r_list_join (ret, list);
 		r_list_free (list);
 	}
 	r_list_foreach (obj->pe64_bins, it, pe64_bin) {
 		list = Pe64_r_bin_mdmp_pe_get_imports (pe64_bin);
-		r_llist_join (ret, list);
+		r_list_join (ret, list);
 		r_list_free (list);
 	}
 	return ret;
@@ -472,12 +450,12 @@ static RList* symbols(RBinFile *arch) {
 
 	r_list_foreach (obj->pe32_bins, it, pe32_bin) {
 		list = Pe32_r_bin_mdmp_pe_get_symbols (pe32_bin);
-		r_llist_join (ret, list);
+		r_list_join (ret, list);
 		r_list_free (list);
 	}
 	r_list_foreach (obj->pe64_bins, it, pe64_bin) {
 		list = Pe64_r_bin_mdmp_pe_get_symbols (pe64_bin);
-		r_llist_join (ret, list);
+		r_list_join (ret, list);
 		r_list_free (list);
 	}
 	return ret;


### PR DESCRIPTION
The MDMP plugin will no longer segfault in the latest git build of r2.
Support for the haddr changes in the core have been added.

I don't know if you will want to merge this as it will no longer work with current release builds (I think). Or does r2pm have a way of versioning?

I know that MDMP is not yet feature complete due to lack of ability to integrate bin plugins with the r2 debugger and I do not have the time to submit a proposal and then code it!  But could we migrate MDMP into the core to prevent these sort of pe dependency regressions or is there a sneaky way that MDMP can access the PE bin headers?

Note: I will submit new regression tests to cater for the haddr ASAP.
