### PR TITLE
add iddt command, fix makefile and proper integration with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
 #  - TESTS="r2pm -i dlang" [BR] https://travis-ci.org/radare/radare2-extras/builds/157522362
   - TESTS="r2pm -i dirtycow"
   - TESTS="r2pm -i duktape"
-  - TESTS="r2pm -i dwarf-parser"
+  - TESTS="r2pm -i dwarf-parser && cd radare2-regressions && make dwarf && cd .."
   - TESTS="r2pm -i r2frida"
 #  - TESTS="r2pm -i io-ewf" # https://github.com/travis-ci/apt-package-whitelist/issues/3205
 #  - TESTS="r2pm -i keystone-lib && r2pm -i keystone && cd radare2-regressions && make keystone && cd .." [BR] https://travis-ci.org/radare/radare2-extras/builds/157522362

--- a/dwarf/Makefile
+++ b/dwarf/Makefile
@@ -1,18 +1,17 @@
 include ../options.mk
 
 LIBDWARFPATH=../../libdwarf-code/
-LIBDWARFLIB=${LIBDWARFPATH}/libdwarf
-EXTRA_TARGETS+=-L$(LIBDWARFPATH)/libdwarf -ldwarf
+LIBDWARFLIB=${LIBDWARFPATH}/libdwarf/
+EXTRA_TARGETS+=${LIBDWARFLIB}/libdwarf.a -lelf -lz
 
 CFLAGS+=$(shell pkg-config --cflags r_util)
-CFLAGS+=-I${LIBDWARFPATH}/libdwarf
+CFLAGS+=-I${LIBDWARFLIB}
 
-LDFLAGS+=-lelf -lz
-CC_LIB=$(CC) -shared $(CFLAGS) $(LDFLAGS) -fPIC
-CC_COR=$(CC_LIB) $(shell pkg-config --libs r_core)
+CC_COR=$(CC) -shared $(CFLAGS) -fPIC
+CC_LIB=$(LDFLAGS) $(shell pkg-config --libs r_core) $(EXTRA_TARGETS)
 
 all:
-	$(CC_COR) -O2 -o dparser.$(LIBEXT) main.c $(EXTRA_TARGETS)
+	$(CC_COR) -O2 -o dparser.$(LIBEXT) main.c $(CC_LIB)
 
 install:
 	cp -f *.$(LIBEXT) $(R2PM_PLUGDIR)

--- a/dwarf/Readme.md
+++ b/dwarf/Readme.md
@@ -28,6 +28,8 @@ idda  structname.member1.submember2      // Print address of submember2 struct w
 iddlg                                    // Print flags in r2 format for all global variables
 iddlf                                    // Print flags in r2 format for all functions
 iddd  structname[.members]*              // Print C-Type declaration
+idddl structname[.members]*              // Print C-Type declaration with sub structures shown
+iddt  structname[.members]*              // Print type and size
 ```
 
 Known problems:
@@ -41,7 +43,6 @@ Please file an issue if you find any
 Things to do:
 -------------
 
- - Print type and size for structure or any of its member (`iddt`)
  - Improve array output. GDB prints it in a more nicer way for situation like array of structs
  - Allow printing of array fields. For example: `struct->field[2]`
  - Issue with setting flags for stubs (they should be named differently)

--- a/dwarf/Readme.md
+++ b/dwarf/Readme.md
@@ -42,7 +42,6 @@ Things to do:
 -------------
 
  - Print type and size for structure or any of its member (`iddt`)
- - Long description of strucutre (`idddl`) (Instead of printing structures as `struct name var_name;`, it should print the nested definition of `struct name`)
  - Improve array output. GDB prints it in a more nicer way for situation like array of structs
  - Allow printing of array fields. For example: `struct->field[2]`
  - Issue with setting flags for stubs (they should be named differently)


### PR DESCRIPTION
With this patch,
`r2pm -i dwarf-parser` seems to work on properly (travis is green).
Fix infinite loop `idddl` command for pointers to struct/union.
Refactor r_cmd_dwarf_call function.