### PR TITLE
r2pm to use local r2-extras cloned repo instead of master in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,25 +28,25 @@ addons:
       - zlib1g-dev
       - swig
 env:
-  - TESTS="r2pm -i armthumb"
-  - TESTS="r2pm -i baleful"
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i armthumb"
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i baleful"
 #  - TESTS="r2pm -i bcl" [BR] https://travis-ci.org/radare/radare2-extras/builds/157522362
-  - TESTS="r2pm -i blackfin"
-  - TESTS="r2pm -i blessr2"
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i blackfin"
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i blessr2"
 #  - TESTS="r2pm -i bpf" [BR] https://travis-ci.org/radare/radare2-extras/builds/157522362
 #  - TESTS="r2pm -i dlang" [BR] https://travis-ci.org/radare/radare2-extras/builds/157522362
   - TESTS="r2pm -i dirtycow"
   - TESTS="r2pm -i duktape"
-  - TESTS="r2pm -i dwarf-parser && cd radare2-regressions && make dwarf && cd .."
+  - TESTS="cd .. && export R2PM_GITDIR=$(pwd) && git clone git://git.code.sf.net/p/libdwarf/code libdwarf-code && cd libdwarf-code && ./configure && make && cd .. && r2pm -i dwarf-parser && cd radare2-extras && cd radare2-regressions && make dwarf && cd .. && cd .. && r2pm -u libdwarf && rm -rf libdwarf-code" #need to remove libdwarf? or travis destroys the vm so no issue in that?
   - TESTS="r2pm -i r2frida"
 #  - TESTS="r2pm -i io-ewf" # https://github.com/travis-ci/apt-package-whitelist/issues/3205
 #  - TESTS="r2pm -i keystone-lib && r2pm -i keystone && cd radare2-regressions && make keystone && cd .." [BR] https://travis-ci.org/radare/radare2-extras/builds/157522362
-  - TESTS="r2pm -i mdmp" && cd radare2-regressions && make extras.mdmp && cd .."
-  - TESTS="r2pm -i microblaze"
-  - TESTS="r2pm -i msil"
-  - TESTS="r2pm -i ppcdisasm"
-  - TESTS="r2pm -i psosvm"
-  - TESTS="r2pm -i pyc"
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i mdmp" && cd radare2-regressions && make extras.mdmp && cd .."
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i microblaze"
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i msil"
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i ppcdisasm"
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i psosvm"
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i pyc"
   - TESTS="r2pm -i vala && r2pm -i valabind && r2pm -i r2api-python"
 #  - TESTS="r2pm -i r2pipe-cs" [BR] https://travis-ci.org/radare/radare2-extras/builds/157522362
   - TESTS="r2pm -i r2pipe-go"
@@ -58,26 +58,26 @@ env:
 #  - TESTS="r2pm -i r2snow" https://travis-ci.org/radare/radare2-extras/jobs/199500082
 #  - TESTS="r2pm -i radeco" [BR] https://travis-ci.org/radare/radare2-extras/builds/157522362
   - TESTS="r2pm -i retdec"
-  - TESTS="r2pm -i swf && cd radare2-regressions && make swf && cd .."
-  - TESTS="r2pm -i m68k-net && cd radare2-regressions && make m68k-extras && cd .."
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i swf && cd radare2-regressions && make swf && cd .."
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i m68k-net && cd radare2-regressions && make m68k-extras && cd .."
 #  - TESTS="r2pm -i swig" Sorry. This package cannot be installed in your home.
   - TESTS="r2pm -i syms2elf"
 #  - TESTS="r2pm -i tcc" [BR] https://travis-ci.org/radare/radare2-extras/builds/157522362
-  - TESTS="r2pm -i unicorn-lib && r2pm -i unicorn"
+  - TESTS="r2pm -i unicorn-lib && r2pm -i unicorn" # need to do this properly
   - TESTS="r2pm -i vala"
   - TESTS="r2pm -i valabind"
   - TESTS="r2pm -i vapi"
-  - TESTS="r2pm -i vc4"
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i vc4"
   - TESTS="r2pm -i winapi"
   - TESTS="r2pm -i www-enyo"
 #  - TESTS="r2pm -i www-m" [BR] https://travis-ci.org/radare/radare2-extras/builds/157522362
   - TESTS="r2pm -i www-p"
   - TESTS="r2pm -i www-t"
-  - TESTS="r2pm -i x86bea"
-  - TESTS="r2pm -i x86tab"
-  - TESTS="r2pm -i x86olly && cd radare2-regressions && make olly-extras && cd .."
-  - TESTS="r2pm -i z80-nc"
-  - TESTS="r2pm -i yara-lib && r2pm -i yara"
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i x86bea"
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i x86tab"
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i x86olly && cd radare2-regressions && make olly-extras && cd .."
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i z80-nc"
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i yara-lib && r2pm -i yara"
 sudo:
   - false
 language:


### PR DESCRIPTION
This should make travis use r2-extras with applied commits of PR instead of using master.

Need review in this line specifically: https://github.com/radare/radare2-extras/compare/master...P4N74:travis-fix?expand=1#diff-354f30a63fb0907d4ad57269548329e3R39