### PR TITLE
MDMP - Support for the next round of breaking changes in the core

### DIFF
--- a/libr/bin/format/mdmp/pe/pe.h
+++ b/libr/bin/format/mdmp/pe/pe.h
@@ -92,6 +92,7 @@ struct PE_(r_bin_pe_obj_t) {
 
 	// these values define the real offset into the untouched binary
 	ut64 nt_header_offset;
+	ut64 section_header_offset;
 	ut64 import_directory_offset;
 	ut64 export_directory_offset;
 	ut64 resource_directory_offset;
@@ -145,3 +146,4 @@ void PE_(r_bin_pe_check_sections)(struct PE_(r_bin_pe_obj_t)* bin, struct r_bin_
 struct r_bin_pe_addr_t *PE_(check_unknow) (struct PE_(r_bin_pe_obj_t) *bin);
 struct r_bin_pe_addr_t *PE_(check_msvcseh) (struct PE_(r_bin_pe_obj_t) *bin);
 struct r_bin_pe_addr_t *PE_(check_mingw) (struct PE_(r_bin_pe_obj_t) *bin);
+bool PE_(r_bin_pe_section_perms)(struct PE_(r_bin_pe_obj_t) *bin, const char *name, int perms);

--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -23,14 +23,14 @@ static ut64 baddr(RBinFile *arch) {
 	return 0LL;
 }
 
-static Sdb *get_sdb(RBinObject *o) {
-	struct r_bin_mdmp_obj *bin;
+static Sdb *get_sdb(RBinFile *arch) {
+	struct r_bin_mdmp_obj *obj;
 
-	if (!o) return NULL;
+	if (!(arch)) return NULL;
 
-	bin = (struct r_bin_mdmp_obj *) o->bin_obj;
+	obj = (struct r_bin_mdmp_obj *)arch->o->bin_obj;
 
-	if (bin && bin->kv) return bin->kv;
+	if (obj && (obj->kv)) return obj->kv;
 
 	return NULL;
 }
@@ -197,7 +197,7 @@ static void *load_bytes(RBinFile *arch, const ut8 *buf, ut64 sz, ut64 loadaddr, 
 	return res;
 }
 
-static int load(RBinFile *arch) {
+static bool load(RBinFile *arch) {
 	const ut8 *bytes = arch ? r_buf_buffer (arch->buf) : NULL;
 	ut64 sz = arch ? r_buf_size (arch->buf) : 0;
 
@@ -461,19 +461,9 @@ static RList* symbols(RBinFile *arch) {
 	return ret;
 }
 
-static int check_bytes(const ut8 *buf, ut64 length) {
+static bool check_bytes(const ut8 *buf, ut64 length) {
 	return buf && (length > sizeof (struct minidump_header))
 		&& (!memcmp (buf, MDMP_MAGIC, 6));
-}
-
-static int check(RBinFile *arch) {
-	const ut8 *bytes;
-	ut64 sz;
-
-	bytes = arch ? r_buf_buffer (arch->buf) : NULL;
-	sz = arch ? r_buf_size (arch->buf) : 0;
-
-	return check_bytes (bytes, sz);
 }
 
 RBinPlugin r_bin_plugin_mdmp = {
@@ -481,7 +471,6 @@ RBinPlugin r_bin_plugin_mdmp = {
 	.desc = "Minidump format r_bin plugin",
 	.license = "LGPL3",
 	.baddr = &baddr,
-	.check = &check,
 	.check_bytes = &check_bytes,
 	.destroy = &destroy,
 	.entries = entries,


### PR DESCRIPTION
This just brings MDMP inline with the new RBinPlugin API changes and updates the PE files to prevent segfaults.

Regression tests now fail only on the info field, I will update this and submit a PR.