### PR TITLE
MDMP - r2 v1.7 Compatability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
   - TESTS="r2pm -i r2frida"
 #  - TESTS="r2pm -i io-ewf" # https://github.com/travis-ci/apt-package-whitelist/issues/3205
 #  - TESTS="r2pm -i keystone-lib && r2pm -i keystone && cd radare2-regressions && make keystone && cd .." [BR] https://travis-ci.org/radare/radare2-extras/builds/157522362
-  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i mdmp" && cd radare2-regressions && make extras.mdmp && cd .."
+  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i mdmp && cd radare2-regressions && ./r2r mdmp && cd .."
   - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i microblaze"
   - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i msil"
   - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i ppcdisasm"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
   - TESTS="r2pm -i r2frida"
 #  - TESTS="r2pm -i io-ewf" # https://github.com/travis-ci/apt-package-whitelist/issues/3205
 #  - TESTS="r2pm -i keystone-lib && r2pm -i keystone && cd radare2-regressions && make keystone && cd .." [BR] https://travis-ci.org/radare/radare2-extras/builds/157522362
-  - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i mdmp && cd radare2-regressions && ./r2r mdmp && cd .."
+  - TESTS="export R2PM_GITDIR='/home/travis/build/radare' && r2pm -i mdmp && cd radare2-regressions && ./r2r mdmp && cd .."
   - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i microblaze"
   - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i msil"
   - TESTS="export R2PM_GITDIR=${TRAVIS_BUILD_DIR} && r2pm -i ppcdisasm"

--- a/libr/bin/format/mdmp/pe/pe.h
+++ b/libr/bin/format/mdmp/pe/pe.h
@@ -62,6 +62,15 @@ struct r_bin_pe_lib_t {
 	int last;
 };
 
+
+typedef struct _PE_RESOURCE {
+	char *timestr;
+	char *type;
+	char *language;
+	int name;
+	Pe_image_resource_data_entry *data;
+} r_pe_resource;
+
 #define GUIDSTR_LEN 34
 #define DBG_FILE_NAME_LEN 255
 
@@ -105,10 +114,11 @@ struct PE_(r_bin_pe_obj_t) {
 	bool verbose;
 	int big_endian;
 	RList* relocs;
+	RList* resources; //RList of r_pe_resources
 	const char* file;
 	struct r_buf_t* b;
 	Sdb *kv;
-	const char* signature_dump;
+	RCMS* cms;
 	bool is_signed;
 };
 
@@ -147,3 +157,4 @@ struct r_bin_pe_addr_t *PE_(check_unknow) (struct PE_(r_bin_pe_obj_t) *bin);
 struct r_bin_pe_addr_t *PE_(check_msvcseh) (struct PE_(r_bin_pe_obj_t) *bin);
 struct r_bin_pe_addr_t *PE_(check_mingw) (struct PE_(r_bin_pe_obj_t) *bin);
 bool PE_(r_bin_pe_section_perms)(struct PE_(r_bin_pe_obj_t) *bin, const char *name, int perms);
+R_API void PE_(bin_pe_parse_resource) (struct PE_(r_bin_pe_obj_t) *bin);

--- a/libr/bin/format/mdmp/pe/pe_specs.h
+++ b/libr/bin/format/mdmp/pe/pe_specs.h
@@ -158,6 +158,103 @@ typedef struct {
 #define PE_IMAGE_SUBSYSTEM_EFI_ROM                 13
 #define PE_IMAGE_SUBSYSTEM_XBOX                    14
 
+//language
+
+#define LANG_NEUTRAL       0x00
+#define LANG_INVARIANT     0x7f
+#define LANG_AFRIKAANS     0x36
+#define LANG_ALBANIAN      0x1c
+#define LANG_ARABIC        0x01
+#define LANG_ARMENIAN      0x2b
+#define LANG_ASSAMESE      0x4d
+#define LANG_AZERI         0x2c
+#define LANG_BASQUE        0x2d
+#define LANG_BELARUSIAN    0x23
+#define LANG_BENGALI       0x45
+#define LANG_BULGARIAN     0x02
+#define LANG_CATALAN       0x03
+#define LANG_CHINESE       0x04
+#define LANG_CROATIAN      0x1a
+#define LANG_CZECH         0x05
+#define LANG_DANISH        0x06
+#define LANG_DIVEHI        0x65
+#define LANG_DUTCH         0x13
+#define LANG_ENGLISH       0x09
+#define LANG_ESTONIAN      0x25
+#define LANG_FAEROESE      0x38
+#define LANG_FARSI         0x29
+#define LANG_FINNISH       0x0b
+#define LANG_FRENCH        0x0c
+#define LANG_GALICIAN      0x56
+#define LANG_GEORGIAN      0x37
+#define LANG_GERMAN        0x07
+#define LANG_GREEK         0x08
+#define LANG_GUJARATI      0x47
+#define LANG_HEBREW        0x0d
+#define LANG_HINDI         0x39
+#define LANG_HUNGARIAN     0x0e
+#define LANG_ICELANDIC     0x0f
+#define LANG_INDONESIAN    0x21
+#define LANG_ITALIAN       0x10
+#define LANG_JAPANESE      0x11
+#define LANG_KANNADA       0x4b
+#define LANG_KASHMIRI      0x60
+#define LANG_KAZAK         0x3f
+#define LANG_KONKANI       0x57
+#define LANG_KOREAN        0x12
+#define LANG_KYRGYZ        0x40
+#define LANG_LATVIAN       0x26
+#define LANG_LITHUANIAN    0x27
+#define LANG_MACEDONIAN    0x2f
+#define LANG_MALAY         0x3e
+#define LANG_MALAYALAM     0x4c
+#define LANG_MANIPURI      0x58
+#define LANG_MARATHI       0x4e
+#define LANG_MONGOLIAN     0x50
+#define LANG_NEPALI        0x61
+#define LANG_NORWEGIAN     0x14
+#define LANG_ORIYA         0x48
+#define LANG_POLISH        0x15
+#define LANG_PORTUGUESE    0x16
+#define LANG_PUNJABI       0x46
+#define LANG_ROMANIAN      0x18
+#define LANG_RUSSIAN       0x19
+#define LANG_SANSKRIT      0x4f
+#define LANG_SERBIAN       0x1a
+#define LANG_SINDHI        0x59
+#define LANG_SLOVAK        0x1b
+#define LANG_SLOVENIAN     0x24
+#define LANG_SPANISH       0x0a
+#define LANG_SWAHILI       0x41
+#define LANG_SWEDISH       0x1d
+#define LANG_SYRIAC        0x5a
+#define LANG_TAMIL         0x49
+#define LANG_TATAR         0x44
+#define LANG_TELUGU        0x4a
+#define LANG_THAI          0x1e
+#define LANG_TURKISH       0x1f
+#define LANG_UKRAINIAN     0x22
+#define LANG_URDU          0x20
+#define LANG_UZBEK         0x43
+#define LANG_VIETNAMESE    0x2a
+#define LANG_GAELIC        0x3c
+#define LANG_MALTESE       0x3a
+#define LANG_MAORI         0x28
+#define LANG_RHAETO_ROMANCE 0x17
+#define LANG_SAAMI         0x3b
+#define LANG_SORBIAN       0x2e
+#define LANG_SUTU          0x30
+#define LANG_TSONGA        0x31
+#define LANG_TSWANA        0x32
+#define LANG_VENDA         0x33
+#define LANG_XHOSA         0x34
+#define LANG_ZULU          0x35
+#define LANG_ESPERANTO     0x8f
+#define LANG_WALON         0x90
+#define LANG_CORNISH       0x91
+#define LANG_WELSH         0x92
+#define LANG_BRETON        0x93
+
 typedef struct {
 	ut32 VirtualAddress;
 	ut32 Size;
@@ -409,6 +506,9 @@ typedef struct {
 	ut32 Reserved;
 } Pe_image_resource_data_entry;
 
+
+//resource types
+#define R_PE_MAX_RESOURCES 2056
 #define PE_RESOURCE_ENTRY_CURSOR          1
 #define PE_RESOURCE_ENTRY_BITMAP          2
 #define PE_RESOURCE_ENTRY_ICON            3

--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -84,6 +84,9 @@ static RBinInfo *info(RBinFile *arch) {
 	ret->rpath = strdup ("NONE");
 	ret->type = strdup ("MDMP (MiniDump crash report data)");
 
+	// FIXME: Needed to fix issue with PLT resolving. Can we get away with setting this for all children bins?
+	ret->has_lit = true;
+
 	if (obj->streams.system_info)
 	{
 		switch (obj->streams.system_info->processor_architecture) {


### PR DESCRIPTION
1. This brings the PE headers in line with r2 v1.7.
2. This fixes a horrible typo that has prevented the regression tests from running.

As a result the regression tests for mdmp do not pass at this moment in time.

First thing to check are the regression tests now running. Next is to work out what has broken the tests.