### PR TITLE
mdmp: Added custom binary info

### DIFF
--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -81,11 +81,15 @@ static RBinInfo *info(RBinFile *arch) {
 	ret->claimed_checksum = strdup (sdb_fmt (0, "0x%08x", obj->hdr->check_sum));
 	ret->file = arch->file ? strdup (arch->file) : NULL;
 	ret->has_va = true;
+	ret->rclass = strdup ("mdmp");
 	ret->rpath = strdup ("NONE");
 	ret->type = strdup ("MDMP (MiniDump crash report data)");
 
 	// FIXME: Needed to fix issue with PLT resolving. Can we get away with setting this for all children bins?
 	ret->has_lit = true;
+
+	sdb_set (arch->sdb, "mdmp.flags", sdb_fmt (0, "0x%08x", obj->hdr->flags), 0);
+	sdb_num_set (arch->sdb, "mdmp.streams", obj->hdr->number_of_streams, 0);
 
 	if (obj->streams.system_info)
 	{


### PR DESCRIPTION
Added useful variables from the MDMP header into the binary infos
section.

We now show the Flags and Streams in `iI`

```
[0x004014e0]> iI
arch     x86
binsz    6646738
+bintype  mdmp
bits     64
canary   false
crypto   false
endian   little
+flags    0x00040802
havecode true
hdr.csum 0x00000000
linenum  false
lsyms    false
machine  AMD64
maxopsz  16
minopsz  1
nx       false
os       Windows NT Workstation 6.1.7601
pcalign  0
pic      false
relocs   false
rpath    NONE
static   false
+streams  14
stripped false
va       true
```