### PR TITLE
Altera Nios disassembler plugin

### DIFF
--- a/libr/asm/Makefile
+++ b/libr/asm/Makefile
@@ -36,6 +36,9 @@ zyan:
 evm:
 	$(MAKE) -C p asm_evm.$(LIBEXT)
 
+nios:
+	$(MAKE) -C p asm_nios.$(LIBEXT)
+
 zyan-install: zyan
 	mkdir -p $(R2PM_PLUGDIR)
 	cp -f p/asm_x86_zyan.$(LIBEXT) $(R2PM_PLUGDIR)
@@ -51,5 +54,6 @@ clean:
 	rm -f p/asm_x86_zyan.$(LIBEXT)
 	rm -f p/asm_atombios.{$(LIBEXT),o}
 	rm -f arch/atombios/atombios.o
+	rm -f p/asm_nios.$(LIBEXT)
 
 include ../../options.mk

--- a/libr/asm/arch/include/dis-asm.h
+++ b/libr/asm/arch/include/dis-asm.h
@@ -274,6 +274,7 @@ extern int print_insn_mn10300		(bfd_vma, disassemble_info *);
 extern int print_insn_moxie		(bfd_vma, disassemble_info *);
 extern int print_insn_msp430		(bfd_vma, disassemble_info *);
 extern int print_insn_mt                (bfd_vma, disassemble_info *);
+extern int print_insn_nios              (bfd_vma, disassemble_info *);
 extern int print_insn_ns32k		(bfd_vma, disassemble_info *);
 extern int print_insn_openrisc		(bfd_vma, disassemble_info *);
 extern int print_insn_pdp11		(bfd_vma, disassemble_info *);

--- a/libr/asm/arch/include/elf/nios.h
+++ b/libr/asm/arch/include/elf/nios.h
@@ -1,0 +1,57 @@
+/* NIOS ELF support for BFD.
+   Copyright (C) 1998 Free Software Foundation, Inc.
+
+This file is part of BFD, the Binary File Descriptor library.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation, Inc.,
+59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+
+#ifndef _ELF_NIOS_H
+#define _ELF_NIOS_H
+
+#include "elf/reloc-macros.h"
+
+/* Relocations.  */
+START_RELOC_NUMBERS (elf_nios_reloc_type)
+  RELOC_NUMBER (R_NIOS_NONE, 0)
+  RELOC_NUMBER (R_NIOS_32, 1)
+  RELOC_NUMBER (R_NIOS_LO16_LO5, 2)
+  RELOC_NUMBER (R_NIOS_LO16_HI11, 3)
+  RELOC_NUMBER (R_NIOS_HI16_LO5, 4)
+  RELOC_NUMBER (R_NIOS_HI16_HI11, 5)
+  RELOC_NUMBER (R_NIOS_PCREL6, 6)
+  RELOC_NUMBER (R_NIOS_PCREL8, 7)
+  RELOC_NUMBER (R_NIOS_PCREL11, 8)
+  RELOC_NUMBER (R_NIOS_16, 9)   
+  RELOC_NUMBER (R_NIOS_H_LO5, 10)
+  RELOC_NUMBER (R_NIOS_H_HI11,11)
+  RELOC_NUMBER (R_NIOS_H_XLO5, 12)
+  RELOC_NUMBER (R_NIOS_H_XHI11, 13)
+  RELOC_NUMBER (R_NIOS_H_16, 14)
+  RELOC_NUMBER (R_NIOS_H_32, 15)
+  RELOC_NUMBER (R_NIOS_GNU_VTINHERIT, 200)
+  RELOC_NUMBER (R_NIOS_GNU_VTENTRY, 201)
+  EMPTY_RELOC  (R_NIOS_max)
+END_RELOC_NUMBERS
+
+#define EF_NIOS_CPU_16		0x00000001      /* nios16 */
+#define EF_NIOS_CPU_32	        0x00000002      /* nios32 */
+#define EF_NIOS_CPU_MASK	0x00000003	/* specific cpu bits */
+#define EF_NIOS_ALL_FLAGS	(EF_NIOS_CPU_MASK)
+
+#endif /* _ELF_NIOS_H */
+
+
+
+

--- a/libr/asm/arch/include/mybfd.h
+++ b/libr/asm/arch/include/mybfd.h
@@ -571,29 +571,7 @@ void bfd_putl16 (bfd_vma, void *);
 
 /* Byte swapping routines which take size and endiannes as arguments.  */
 
-//bfd_uint64_t bfd_get_bits (const void *, int, bfd_boolean);
-static inline bfd_uint64_t
-bfd_get_bits (const void *p, int bits, bfd_boolean big_p)
-{
-  const bfd_byte *addr = (const bfd_byte *) p;
-  bfd_uint64_t data;
-  int i;
-  int bytes;
-
-  if (bits % 8 != 0)
-    return 0;
-
-  data = 0;
-  bytes = bits / 8;
-  for (i = 0; i < bytes; i++)
-    {
-      int addr_index = big_p ? i : bytes - i - 1;
-
-      data = (data << 8) | addr[addr_index];
-    }
-
-  return data;
-}
+bfd_uint64_t bfd_get_bits (const void *, int, bfd_boolean);
 void bfd_put_bits (bfd_uint64_t, void *, int, bfd_boolean);
 
 extern bfd_boolean bfd_section_already_linked_table_init (void);

--- a/libr/asm/arch/include/mybfd.h
+++ b/libr/asm/arch/include/mybfd.h
@@ -1927,6 +1927,9 @@ enum bfd_architecture
 #define bfd_mach_mn10300               300
 #define bfd_mach_am33          330
 #define bfd_mach_am33_2        332
+  bfd_arch_nios,
+#define bfd_mach_nios16        0
+#define bfd_mach_nios32        1
   bfd_arch_fr30,
 #define bfd_mach_fr30          0x46523330
   bfd_arch_frv,
@@ -3433,6 +3436,21 @@ the opcode.  */
 significant 7 bits of a 23-bit extended address are placed into
 the opcode.  */
   BFD_RELOC_TIC54X_MS7_OF_23,
+
+/* Altera Nios Relocations. */
+  BFD_RELOC_NIOS_LO16_LO5,
+  BFD_RELOC_NIOS_LO16_HI11,
+  BFD_RELOC_NIOS_HI16_LO5,
+  BFD_RELOC_NIOS_HI16_HI11,
+  BFD_RELOC_NIOS_PCREL6,
+  BFD_RELOC_NIOS_PCREL8,
+  BFD_RELOC_NIOS_PCREL11,
+  BFD_RELOC_NIOS_H_LO5,
+  BFD_RELOC_NIOS_H_HI11,
+  BFD_RELOC_NIOS_H_XLO5,
+  BFD_RELOC_NIOS_H_XHI11,
+  BFD_RELOC_NIOS_H_16,
+  BFD_RELOC_NIOS_H_32,
 
 /* This is a 48 bit reloc for the FR30 that stores 32 bits.  */
   BFD_RELOC_FR30_48,

--- a/libr/asm/arch/include/safe-ctype.h
+++ b/libr/asm/arch/include/safe-ctype.h
@@ -1,0 +1,150 @@
+/* <ctype.h> replacement macros.
+
+   Copyright (C) 2000-2018 Free Software Foundation, Inc.
+   Contributed by Zack Weinberg <zackw@stanford.edu>.
+
+This file is part of the libiberty library.
+Libiberty is free software; you can redistribute it and/or
+modify it under the terms of the GNU Library General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+Libiberty is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public
+License along with libiberty; see the file COPYING.LIB.  If
+not, write to the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+Boston, MA 02110-1301, USA.  */
+
+/* This is a compatible replacement of the standard C library's <ctype.h>
+   with the following properties:
+
+   - Implements all isxxx() macros required by C99.
+   - Also implements some character classes useful when
+     parsing C-like languages.
+   - Does not change behavior depending on the current locale.
+   - Behaves properly for all values in the range of a signed or
+     unsigned char.
+
+   To avoid conflicts, this header defines the isxxx functions in upper
+   case, e.g. ISALPHA not isalpha.  */
+
+#ifndef SAFE_CTYPE_H
+#define SAFE_CTYPE_H
+
+/* Determine host character set.  */
+#define HOST_CHARSET_UNKNOWN 0
+#define HOST_CHARSET_ASCII   1
+#define HOST_CHARSET_EBCDIC  2
+
+#if  '\n' == 0x0A && ' ' == 0x20 && '0' == 0x30 \
+   && 'A' == 0x41 && 'a' == 0x61 && '!' == 0x21
+#  define HOST_CHARSET HOST_CHARSET_ASCII
+#else
+# if '\n' == 0x15 && ' ' == 0x40 && '0' == 0xF0 \
+   && 'A' == 0xC1 && 'a' == 0x81 && '!' == 0x5A
+#  define HOST_CHARSET HOST_CHARSET_EBCDIC
+# else
+#  define HOST_CHARSET HOST_CHARSET_UNKNOWN
+# endif
+#endif
+
+/* Categories.  */
+
+enum {
+  /* In C99 */
+  _sch_isblank  = 0x0001,	/* space \t */
+  _sch_iscntrl  = 0x0002,	/* nonprinting characters */
+  _sch_isdigit  = 0x0004,	/* 0-9 */
+  _sch_islower  = 0x0008,	/* a-z */
+  _sch_isprint  = 0x0010,	/* any printing character including ' ' */
+  _sch_ispunct  = 0x0020,	/* all punctuation */
+  _sch_isspace  = 0x0040,	/* space \t \n \r \f \v */
+  _sch_isupper  = 0x0080,	/* A-Z */
+  _sch_isxdigit = 0x0100,	/* 0-9A-Fa-f */
+
+  /* Extra categories useful to cpplib.  */
+  _sch_isidst	= 0x0200,	/* A-Za-z_ */
+  _sch_isvsp    = 0x0400,	/* \n \r */
+  _sch_isnvsp   = 0x0800,	/* space \t \f \v \0 */
+
+  /* Combinations of the above.  */
+  _sch_isalpha  = _sch_isupper|_sch_islower,	/* A-Za-z */
+  _sch_isalnum  = _sch_isalpha|_sch_isdigit,	/* A-Za-z0-9 */
+  _sch_isidnum  = _sch_isidst|_sch_isdigit,	/* A-Za-z0-9_ */
+  _sch_isgraph  = _sch_isalnum|_sch_ispunct,	/* isprint and not space */
+  _sch_iscppsp  = _sch_isvsp|_sch_isnvsp,	/* isspace + \0 */
+  _sch_isbasic  = _sch_isprint|_sch_iscppsp     /* basic charset of ISO C
+						   (plus ` and @)  */
+};
+
+/* Character classification.  */
+extern const unsigned short _sch_istable[256];
+
+#define _sch_test(c, bit) (_sch_istable[(c) & 0xff] & (unsigned short)(bit))
+
+#define ISALPHA(c)  _sch_test(c, _sch_isalpha)
+#define ISALNUM(c)  _sch_test(c, _sch_isalnum)
+#define ISBLANK(c)  _sch_test(c, _sch_isblank)
+#define ISCNTRL(c)  _sch_test(c, _sch_iscntrl)
+#define ISDIGIT(c)  _sch_test(c, _sch_isdigit)
+#define ISGRAPH(c)  _sch_test(c, _sch_isgraph)
+#define ISLOWER(c)  _sch_test(c, _sch_islower)
+#define ISPRINT(c)  _sch_test(c, _sch_isprint)
+#define ISPUNCT(c)  _sch_test(c, _sch_ispunct)
+#define ISSPACE(c)  _sch_test(c, _sch_isspace)
+#define ISUPPER(c)  _sch_test(c, _sch_isupper)
+#define ISXDIGIT(c) _sch_test(c, _sch_isxdigit)
+
+#define ISIDNUM(c)	_sch_test(c, _sch_isidnum)
+#define ISIDST(c)	_sch_test(c, _sch_isidst)
+#define IS_ISOBASIC(c)	_sch_test(c, _sch_isbasic)
+#define IS_VSPACE(c)	_sch_test(c, _sch_isvsp)
+#define IS_NVSPACE(c)	_sch_test(c, _sch_isnvsp)
+#define IS_SPACE_OR_NUL(c)	_sch_test(c, _sch_iscppsp)
+
+/* Character transformation.  */
+extern const unsigned char  _sch_toupper[256];
+extern const unsigned char  _sch_tolower[256];
+#define TOUPPER(c) _sch_toupper[(c) & 0xff]
+#define TOLOWER(c) _sch_tolower[(c) & 0xff]
+
+/* Prevent the users of safe-ctype.h from accidently using the routines
+   from ctype.h.  Initially, the approach was to produce an error when
+   detecting that ctype.h has been included.  But this was causing
+   trouble as ctype.h might get indirectly included as a result of
+   including another system header (for instance gnulib's stdint.h).
+   So we include ctype.h here and then immediately redefine its macros.  */
+
+#include <ctype.h>
+#undef isalpha
+#define isalpha(c) do_not_use_isalpha_with_safe_ctype
+#undef isalnum
+#define isalnum(c) do_not_use_isalnum_with_safe_ctype
+#undef iscntrl
+#define iscntrl(c) do_not_use_iscntrl_with_safe_ctype
+#undef isdigit
+#define isdigit(c) do_not_use_isdigit_with_safe_ctype
+#undef isgraph
+#define isgraph(c) do_not_use_isgraph_with_safe_ctype
+#undef islower
+#define islower(c) do_not_use_islower_with_safe_ctype
+#undef isprint
+#define isprint(c) do_not_use_isprint_with_safe_ctype
+#undef ispunct
+#define ispunct(c) do_not_use_ispunct_with_safe_ctype
+#undef isspace
+#define isspace(c) do_not_use_isspace_with_safe_ctype
+#undef isupper
+#define isupper(c) do_not_use_isupper_with_safe_ctype
+#undef isxdigit
+#define isxdigit(c) do_not_use_isxdigit_with_safe_ctype
+#undef toupper
+#define toupper(c) do_not_use_toupper_with_safe_ctype
+#undef tolower
+#define tolower(c) do_not_use_tolower_with_safe_ctype
+
+#endif /* SAFE_CTYPE_H */

--- a/libr/asm/arch/include/xregex.h
+++ b/libr/asm/arch/include/xregex.h
@@ -1,0 +1,29 @@
+/* This file redefines all regex external names before including
+   a renamed copy of glibc's regex.h.  */
+
+#ifndef _XREGEX_H
+#define _XREGEX_H 1
+
+#  define regfree xregfree 
+#  define regexec xregexec
+#  define regcomp xregcomp
+#  define regerror xregerror
+#  define regoff_t xregoff_t
+#  define re_set_registers xre_set_registers
+#  define re_match_2 xre_match_2
+#  define re_match xre_match
+#  define re_search xre_search
+#  define re_compile_pattern xre_compile_pattern
+#  define re_set_syntax xre_set_syntax
+#  define re_search_2 xre_search_2
+#  define re_compile_fastmap xre_compile_fastmap
+#  define re_syntax_options xre_syntax_options
+#  define re_max_failures xre_max_failures
+
+#  define _REGEX_RE_COMP
+#  define re_comp xre_comp
+#  define re_exec xre_exec
+
+#include "xregex2.h"
+
+#endif /* xregex.h */

--- a/libr/asm/arch/include/xregex2.h
+++ b/libr/asm/arch/include/xregex2.h
@@ -1,0 +1,564 @@
+/* Definitions for data structures and routines for the regular
+   expression library, version 0.12.
+
+   Copyright (C) 1985-2018 Free Software Foundation, Inc.
+
+   This file is part of the GNU C Library.  Its master source is NOT part of
+   the C library, however.  The master source lives in /gd/gnu/lib.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, write to the Free
+   Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA.  */
+
+#ifndef _REGEX_H
+#define _REGEX_H 1
+
+/* Allow the use in C++ code.  */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* POSIX says that <sys/types.h> must be included (by the caller) before
+   <regex.h>.  */
+
+#if !defined _POSIX_C_SOURCE && !defined _POSIX_SOURCE && defined VMS
+/* VMS doesn't have `size_t' in <sys/types.h>, even though POSIX says it
+   should be there.  */
+# include <stddef.h>
+#endif
+
+/* The following two types have to be signed and unsigned integer type
+   wide enough to hold a value of a pointer.  For most ANSI compilers
+   ptrdiff_t and size_t should be likely OK.  Still size of these two
+   types is 2 for Microsoft C.  Ugh... */
+typedef long int s_reg_t;
+typedef unsigned long int active_reg_t;
+
+/* The following bits are used to determine the regexp syntax we
+   recognize.  The set/not-set meanings are chosen so that Emacs syntax
+   remains the value 0.  The bits are given in alphabetical order, and
+   the definitions shifted by one from the previous bit; thus, when we
+   add or remove a bit, only one other definition need change.  */
+typedef unsigned long int reg_syntax_t;
+
+/* If this bit is not set, then \ inside a bracket expression is literal.
+   If set, then such a \ quotes the following character.  */
+#define RE_BACKSLASH_ESCAPE_IN_LISTS ((unsigned long int) 1)
+
+/* If this bit is not set, then + and ? are operators, and \+ and \? are
+     literals.
+   If set, then \+ and \? are operators and + and ? are literals.  */
+#define RE_BK_PLUS_QM (RE_BACKSLASH_ESCAPE_IN_LISTS << 1)
+
+/* If this bit is set, then character classes are supported.  They are:
+     [:alpha:], [:upper:], [:lower:],  [:digit:], [:alnum:], [:xdigit:],
+     [:space:], [:print:], [:punct:], [:graph:], and [:cntrl:].
+   If not set, then character classes are not supported.  */
+#define RE_CHAR_CLASSES (RE_BK_PLUS_QM << 1)
+
+/* If this bit is set, then ^ and $ are always anchors (outside bracket
+     expressions, of course).
+   If this bit is not set, then it depends:
+        ^  is an anchor if it is at the beginning of a regular
+           expression or after an open-group or an alternation operator;
+        $  is an anchor if it is at the end of a regular expression, or
+           before a close-group or an alternation operator.
+
+   This bit could be (re)combined with RE_CONTEXT_INDEP_OPS, because
+   POSIX draft 11.2 says that * etc. in leading positions is undefined.
+   We already implemented a previous draft which made those constructs
+   invalid, though, so we haven't changed the code back.  */
+#define RE_CONTEXT_INDEP_ANCHORS (RE_CHAR_CLASSES << 1)
+
+/* If this bit is set, then special characters are always special
+     regardless of where they are in the pattern.
+   If this bit is not set, then special characters are special only in
+     some contexts; otherwise they are ordinary.  Specifically,
+     * + ? and intervals are only special when not after the beginning,
+     open-group, or alternation operator.  */
+#define RE_CONTEXT_INDEP_OPS (RE_CONTEXT_INDEP_ANCHORS << 1)
+
+/* If this bit is set, then *, +, ?, and { cannot be first in an re or
+     immediately after an alternation or begin-group operator.  */
+#define RE_CONTEXT_INVALID_OPS (RE_CONTEXT_INDEP_OPS << 1)
+
+/* If this bit is set, then . matches newline.
+   If not set, then it doesn't.  */
+#define RE_DOT_NEWLINE (RE_CONTEXT_INVALID_OPS << 1)
+
+/* If this bit is set, then . doesn't match NUL.
+   If not set, then it does.  */
+#define RE_DOT_NOT_NULL (RE_DOT_NEWLINE << 1)
+
+/* If this bit is set, nonmatching lists [^...] do not match newline.
+   If not set, they do.  */
+#define RE_HAT_LISTS_NOT_NEWLINE (RE_DOT_NOT_NULL << 1)
+
+/* If this bit is set, either \{...\} or {...} defines an
+     interval, depending on RE_NO_BK_BRACES.
+   If not set, \{, \}, {, and } are literals.  */
+#define RE_INTERVALS (RE_HAT_LISTS_NOT_NEWLINE << 1)
+
+/* If this bit is set, +, ? and | aren't recognized as operators.
+   If not set, they are.  */
+#define RE_LIMITED_OPS (RE_INTERVALS << 1)
+
+/* If this bit is set, newline is an alternation operator.
+   If not set, newline is literal.  */
+#define RE_NEWLINE_ALT (RE_LIMITED_OPS << 1)
+
+/* If this bit is set, then `{...}' defines an interval, and \{ and \}
+     are literals.
+  If not set, then `\{...\}' defines an interval.  */
+#define RE_NO_BK_BRACES (RE_NEWLINE_ALT << 1)
+
+/* If this bit is set, (...) defines a group, and \( and \) are literals.
+   If not set, \(...\) defines a group, and ( and ) are literals.  */
+#define RE_NO_BK_PARENS (RE_NO_BK_BRACES << 1)
+
+/* If this bit is set, then \<digit> matches <digit>.
+   If not set, then \<digit> is a back-reference.  */
+#define RE_NO_BK_REFS (RE_NO_BK_PARENS << 1)
+
+/* If this bit is set, then | is an alternation operator, and \| is literal.
+   If not set, then \| is an alternation operator, and | is literal.  */
+#define RE_NO_BK_VBAR (RE_NO_BK_REFS << 1)
+
+/* If this bit is set, then an ending range point collating higher
+     than the starting range point, as in [z-a], is invalid.
+   If not set, then when ending range point collates higher than the
+     starting range point, the range is ignored.  */
+#define RE_NO_EMPTY_RANGES (RE_NO_BK_VBAR << 1)
+
+/* If this bit is set, then an unmatched ) is ordinary.
+   If not set, then an unmatched ) is invalid.  */
+#define RE_UNMATCHED_RIGHT_PAREN_ORD (RE_NO_EMPTY_RANGES << 1)
+
+/* If this bit is set, succeed as soon as we match the whole pattern,
+   without further backtracking.  */
+#define RE_NO_POSIX_BACKTRACKING (RE_UNMATCHED_RIGHT_PAREN_ORD << 1)
+
+/* If this bit is set, do not process the GNU regex operators.
+   If not set, then the GNU regex operators are recognized. */
+#define RE_NO_GNU_OPS (RE_NO_POSIX_BACKTRACKING << 1)
+
+/* If this bit is set, turn on internal regex debugging.
+   If not set, and debugging was on, turn it off.
+   This only works if regex.c is compiled -DDEBUG.
+   We define this bit always, so that all that's needed to turn on
+   debugging is to recompile regex.c; the calling code can always have
+   this bit set, and it won't affect anything in the normal case. */
+#define RE_DEBUG (RE_NO_GNU_OPS << 1)
+
+/* If this bit is set, a syntactically invalid interval is treated as
+   a string of ordinary characters.  For example, the ERE 'a{1' is
+   treated as 'a\{1'.  */
+#define RE_INVALID_INTERVAL_ORD (RE_DEBUG << 1)
+
+/* This global variable defines the particular regexp syntax to use (for
+   some interfaces).  When a regexp is compiled, the syntax used is
+   stored in the pattern buffer, so changing this does not affect
+   already-compiled regexps.  */
+extern reg_syntax_t re_syntax_options;
+
+/* Define combinations of the above bits for the standard possibilities.
+   (The [[[ comments delimit what gets put into the Texinfo file, so
+   don't delete them!)  */
+/* [[[begin syntaxes]]] */
+#define RE_SYNTAX_EMACS 0
+
+#define RE_SYNTAX_AWK							\
+  (RE_BACKSLASH_ESCAPE_IN_LISTS   | RE_DOT_NOT_NULL			\
+   | RE_NO_BK_PARENS              | RE_NO_BK_REFS			\
+   | RE_NO_BK_VBAR                | RE_NO_EMPTY_RANGES			\
+   | RE_DOT_NEWLINE		  | RE_CONTEXT_INDEP_ANCHORS		\
+   | RE_UNMATCHED_RIGHT_PAREN_ORD | RE_NO_GNU_OPS)
+
+#define RE_SYNTAX_GNU_AWK						\
+  ((RE_SYNTAX_POSIX_EXTENDED | RE_BACKSLASH_ESCAPE_IN_LISTS | RE_DEBUG)	\
+   & ~(RE_DOT_NOT_NULL | RE_INTERVALS | RE_CONTEXT_INDEP_OPS))
+
+#define RE_SYNTAX_POSIX_AWK 						\
+  (RE_SYNTAX_POSIX_EXTENDED | RE_BACKSLASH_ESCAPE_IN_LISTS		\
+   | RE_INTERVALS	    | RE_NO_GNU_OPS)
+
+#define RE_SYNTAX_GREP							\
+  (RE_BK_PLUS_QM              | RE_CHAR_CLASSES				\
+   | RE_HAT_LISTS_NOT_NEWLINE | RE_INTERVALS				\
+   | RE_NEWLINE_ALT)
+
+#define RE_SYNTAX_EGREP							\
+  (RE_CHAR_CLASSES        | RE_CONTEXT_INDEP_ANCHORS			\
+   | RE_CONTEXT_INDEP_OPS | RE_HAT_LISTS_NOT_NEWLINE			\
+   | RE_NEWLINE_ALT       | RE_NO_BK_PARENS				\
+   | RE_NO_BK_VBAR)
+
+#define RE_SYNTAX_POSIX_EGREP						\
+  (RE_SYNTAX_EGREP | RE_INTERVALS | RE_NO_BK_BRACES			\
+   | RE_INVALID_INTERVAL_ORD)
+
+/* P1003.2/D11.2, section 4.20.7.1, lines 5078ff.  */
+#define RE_SYNTAX_ED RE_SYNTAX_POSIX_BASIC
+
+#define RE_SYNTAX_SED RE_SYNTAX_POSIX_BASIC
+
+/* Syntax bits common to both basic and extended POSIX regex syntax.  */
+#define _RE_SYNTAX_POSIX_COMMON						\
+  (RE_CHAR_CLASSES | RE_DOT_NEWLINE      | RE_DOT_NOT_NULL		\
+   | RE_INTERVALS  | RE_NO_EMPTY_RANGES)
+
+#define RE_SYNTAX_POSIX_BASIC						\
+  (_RE_SYNTAX_POSIX_COMMON | RE_BK_PLUS_QM)
+
+/* Differs from ..._POSIX_BASIC only in that RE_BK_PLUS_QM becomes
+   RE_LIMITED_OPS, i.e., \? \+ \| are not recognized.  Actually, this
+   isn't minimal, since other operators, such as \`, aren't disabled.  */
+#define RE_SYNTAX_POSIX_MINIMAL_BASIC					\
+  (_RE_SYNTAX_POSIX_COMMON | RE_LIMITED_OPS)
+
+#define RE_SYNTAX_POSIX_EXTENDED					\
+  (_RE_SYNTAX_POSIX_COMMON  | RE_CONTEXT_INDEP_ANCHORS			\
+   | RE_CONTEXT_INDEP_OPS   | RE_NO_BK_BRACES				\
+   | RE_NO_BK_PARENS        | RE_NO_BK_VBAR				\
+   | RE_CONTEXT_INVALID_OPS | RE_UNMATCHED_RIGHT_PAREN_ORD)
+
+/* Differs from ..._POSIX_EXTENDED in that RE_CONTEXT_INDEP_OPS is
+   removed and RE_NO_BK_REFS is added.  */
+#define RE_SYNTAX_POSIX_MINIMAL_EXTENDED				\
+  (_RE_SYNTAX_POSIX_COMMON  | RE_CONTEXT_INDEP_ANCHORS			\
+   | RE_CONTEXT_INVALID_OPS | RE_NO_BK_BRACES				\
+   | RE_NO_BK_PARENS        | RE_NO_BK_REFS				\
+   | RE_NO_BK_VBAR	    | RE_UNMATCHED_RIGHT_PAREN_ORD)
+/* [[[end syntaxes]]] */
+
+/* Maximum number of duplicates an interval can allow.  Some systems
+   (erroneously) define this in other header files, but we want our
+   value, so remove any previous define.  */
+#ifdef RE_DUP_MAX
+# undef RE_DUP_MAX
+#endif
+/* If sizeof(int) == 2, then ((1 << 15) - 1) overflows.  */
+#define RE_DUP_MAX (0x7fff)
+
+
+/* POSIX `cflags' bits (i.e., information for `regcomp').  */
+
+/* If this bit is set, then use extended regular expression syntax.
+   If not set, then use basic regular expression syntax.  */
+#define REG_EXTENDED 1
+
+/* If this bit is set, then ignore case when matching.
+   If not set, then case is significant.  */
+#define REG_ICASE (REG_EXTENDED << 1)
+
+/* If this bit is set, then anchors do not match at newline
+     characters in the string.
+   If not set, then anchors do match at newlines.  */
+#define REG_NEWLINE (REG_ICASE << 1)
+
+/* If this bit is set, then report only success or fail in regexec.
+   If not set, then returns differ between not matching and errors.  */
+#define REG_NOSUB (REG_NEWLINE << 1)
+
+
+/* POSIX `eflags' bits (i.e., information for regexec).  */
+
+/* If this bit is set, then the beginning-of-line operator doesn't match
+     the beginning of the string (presumably because it's not the
+     beginning of a line).
+   If not set, then the beginning-of-line operator does match the
+     beginning of the string.  */
+#define REG_NOTBOL 1
+
+/* Like REG_NOTBOL, except for the end-of-line.  */
+#define REG_NOTEOL (1 << 1)
+
+
+/* If any error codes are removed, changed, or added, update the
+   `re_error_msg' table in regex.c.  */
+typedef enum
+{
+#ifdef _XOPEN_SOURCE
+  REG_ENOSYS = -1,	/* This will never happen for this implementation.  */
+#endif
+
+  REG_NOERROR = 0,	/* Success.  */
+  REG_NOMATCH,		/* Didn't find a match (for regexec).  */
+
+  /* POSIX regcomp return error codes.  (In the order listed in the
+     standard.)  */
+  REG_BADPAT,		/* Invalid pattern.  */
+  REG_ECOLLATE,		/* Not implemented.  */
+  REG_ECTYPE,		/* Invalid character class name.  */
+  REG_EESCAPE,		/* Trailing backslash.  */
+  REG_ESUBREG,		/* Invalid back reference.  */
+  REG_EBRACK,		/* Unmatched left bracket.  */
+  REG_EPAREN,		/* Parenthesis imbalance.  */
+  REG_EBRACE,		/* Unmatched \{.  */
+  REG_BADBR,		/* Invalid contents of \{\}.  */
+  REG_ERANGE,		/* Invalid range end.  */
+  REG_ESPACE,		/* Ran out of memory.  */
+  REG_BADRPT,		/* No preceding re for repetition op.  */
+
+  /* Error codes we've added.  */
+  REG_EEND,		/* Premature end.  */
+  REG_ESIZE,		/* Compiled pattern bigger than 2^16 bytes.  */
+  REG_ERPAREN		/* Unmatched ) or \); not returned from regcomp.  */
+} reg_errcode_t;
+
+/* This data structure represents a compiled pattern.  Before calling
+   the pattern compiler, the fields `buffer', `allocated', `fastmap',
+   `translate', and `no_sub' can be set.  After the pattern has been
+   compiled, the `re_nsub' field is available.  All other fields are
+   private to the regex routines.  */
+
+#ifndef RE_TRANSLATE_TYPE
+# define RE_TRANSLATE_TYPE char *
+#endif
+
+struct re_pattern_buffer
+{
+/* [[[begin pattern_buffer]]] */
+	/* Space that holds the compiled pattern.  It is declared as
+          `unsigned char *' because its elements are
+           sometimes used as array indexes.  */
+  unsigned char *buffer;
+
+	/* Number of bytes to which `buffer' points.  */
+  unsigned long int allocated;
+
+	/* Number of bytes actually used in `buffer'.  */
+  unsigned long int used;
+
+        /* Syntax setting with which the pattern was compiled.  */
+  reg_syntax_t syntax;
+
+        /* Pointer to a fastmap, if any, otherwise zero.  re_search uses
+           the fastmap, if there is one, to skip over impossible
+           starting points for matches.  */
+  char *fastmap;
+
+        /* Either a translate table to apply to all characters before
+           comparing them, or zero for no translation.  The translation
+           is applied to a pattern when it is compiled and to a string
+           when it is matched.  */
+  RE_TRANSLATE_TYPE translate;
+
+	/* Number of subexpressions found by the compiler.  */
+  size_t re_nsub;
+
+        /* Zero if this pattern cannot match the empty string, one else.
+           Well, in truth it's used only in `re_search_2', to see
+           whether or not we should use the fastmap, so we don't set
+           this absolutely perfectly; see `re_compile_fastmap' (the
+           `duplicate' case).  */
+  unsigned can_be_null : 1;
+
+        /* If REGS_UNALLOCATED, allocate space in the `regs' structure
+             for `max (RE_NREGS, re_nsub + 1)' groups.
+           If REGS_REALLOCATE, reallocate space if necessary.
+           If REGS_FIXED, use what's there.  */
+#define REGS_UNALLOCATED 0
+#define REGS_REALLOCATE 1
+#define REGS_FIXED 2
+  unsigned regs_allocated : 2;
+
+        /* Set to zero when `regex_compile' compiles a pattern; set to one
+           by `re_compile_fastmap' if it updates the fastmap.  */
+  unsigned fastmap_accurate : 1;
+
+        /* If set, `re_match_2' does not return information about
+           subexpressions.  */
+  unsigned no_sub : 1;
+
+        /* If set, a beginning-of-line anchor doesn't match at the
+           beginning of the string.  */
+  unsigned not_bol : 1;
+
+        /* Similarly for an end-of-line anchor.  */
+  unsigned not_eol : 1;
+
+        /* If true, an anchor at a newline matches.  */
+  unsigned newline_anchor : 1;
+
+/* [[[end pattern_buffer]]] */
+};
+
+typedef struct re_pattern_buffer regex_t;
+
+/* Type for byte offsets within the string.  POSIX mandates this.  */
+typedef int regoff_t;
+
+
+/* This is the structure we store register match data in.  See
+   regex.texinfo for a full description of what registers match.  */
+struct re_registers
+{
+  unsigned num_regs;
+  regoff_t *start;
+  regoff_t *end;
+};
+
+
+/* If `regs_allocated' is REGS_UNALLOCATED in the pattern buffer,
+   `re_match_2' returns information about at least this many registers
+   the first time a `regs' structure is passed.  */
+#ifndef RE_NREGS
+# define RE_NREGS 30
+#endif
+
+
+/* POSIX specification for registers.  Aside from the different names than
+   `re_registers', POSIX uses an array of structures, instead of a
+   structure of arrays.  */
+typedef struct
+{
+  regoff_t rm_so;  /* Byte offset from string's start to substring's start.  */
+  regoff_t rm_eo;  /* Byte offset from string's start to substring's end.  */
+} regmatch_t;
+
+/* Declarations for routines.  */
+
+/* To avoid duplicating every routine declaration -- once with a
+   prototype (if we are ANSI), and once without (if we aren't) -- we
+   use the following macro to declare argument types.  This
+   unfortunately clutters up the declarations a bit, but I think it's
+   worth it.  */
+
+/* Sets the current default syntax to SYNTAX, and return the old syntax.
+   You can also simply assign to the `re_syntax_options' variable.  */
+extern reg_syntax_t re_set_syntax (reg_syntax_t syntax);
+
+/* Compile the regular expression PATTERN, with length LENGTH
+   and syntax given by the global `re_syntax_options', into the buffer
+   BUFFER.  Return NULL if successful, and an error string if not.  */
+extern const char *re_compile_pattern (const char *pattern, size_t length,
+                                       struct re_pattern_buffer *buffer);
+
+
+/* Compile a fastmap for the compiled pattern in BUFFER; used to
+   accelerate searches.  Return 0 if successful and -2 if was an
+   internal error.  */
+extern int re_compile_fastmap (struct re_pattern_buffer *buffer);
+
+
+/* Search in the string STRING (with length LENGTH) for the pattern
+   compiled into BUFFER.  Start searching at position START, for RANGE
+   characters.  Return the starting position of the match, -1 for no
+   match, or -2 for an internal error.  Also return register
+   information in REGS (if REGS and BUFFER->no_sub are nonzero).  */
+extern int re_search (struct re_pattern_buffer *buffer, const char *string,
+                      int length, int start, int range,
+                      struct re_registers *regs);
+
+
+/* Like `re_search', but search in the concatenation of STRING1 and
+   STRING2.  Also, stop searching at index START + STOP.  */
+extern int re_search_2 (struct re_pattern_buffer *buffer, const char *string1,
+                        int length1, const char *string2, int length2,
+                        int start, int range, struct re_registers *regs,
+                        int stop);
+
+
+/* Like `re_search', but return how many characters in STRING the regexp
+   in BUFFER matched, starting at position START.  */
+extern int re_match (struct re_pattern_buffer *buffer, const char *string,
+                     int length, int start, struct re_registers *regs);
+
+
+/* Relates to `re_match' as `re_search_2' relates to `re_search'.  */
+extern int re_match_2 (struct re_pattern_buffer *buffer, const char *string1,
+                       int length1, const char *string2, int length2,
+                       int start, struct re_registers *regs, int stop);
+
+
+/* Set REGS to hold NUM_REGS registers, storing them in STARTS and
+   ENDS.  Subsequent matches using BUFFER and REGS will use this memory
+   for recording register information.  STARTS and ENDS must be
+   allocated with malloc, and must each be at least `NUM_REGS * sizeof
+   (regoff_t)' bytes long.
+
+   If NUM_REGS == 0, then subsequent matches should allocate their own
+   register data.
+
+   Unless this function is called, the first search or match using
+   PATTERN_BUFFER will allocate its own register data, without
+   freeing the old data.  */
+extern void re_set_registers (struct re_pattern_buffer *buffer,
+                              struct re_registers *regs,
+                              unsigned num_regs, regoff_t *starts,
+                              regoff_t *ends);
+
+#if defined _REGEX_RE_COMP || defined _LIBC
+# ifndef _CRAY
+/* 4.2 bsd compatibility.  */
+extern char *re_comp (const char *);
+extern int re_exec (const char *);
+# endif
+#endif
+
+/* GCC 2.95 and later have "__restrict"; C99 compilers have
+   "restrict", and "configure" may have defined "restrict".  */
+#ifndef __restrict
+# if ! (2 < __GNUC__ || (2 == __GNUC__ && 95 <= __GNUC_MINOR__))
+#  if defined restrict || 199901L <= __STDC_VERSION__
+#   define __restrict restrict
+#  else
+#   define __restrict
+#  endif
+# endif
+#endif
+
+/* GCC 3.1 and later support declaring arrays as non-overlapping
+   using the syntax array_name[restrict]  */
+#ifndef __restrict_arr
+# if ! (3 < __GNUC__ || (3 == __GNUC__ && 1 <= __GNUC_MINOR__)) || defined (__GNUG__)
+#  define __restrict_arr
+# else
+#  define __restrict_arr __restrict
+# endif
+#endif
+
+/* POSIX compatibility.  */
+extern int regcomp (regex_t *__restrict __preg,
+                    const char *__restrict __pattern,
+                    int __cflags);
+
+#if (__GNUC__)
+__extension__
+#endif
+extern int regexec (const regex_t *__restrict __preg,
+                    const char *__restrict __string, size_t __nmatch,
+                    regmatch_t __pmatch[__restrict_arr],
+                    int __eflags);
+
+extern size_t regerror (int __errcode, const regex_t *__preg,
+                        char *__errbuf, size_t __errbuf_size);
+
+extern void regfree (regex_t *__preg);
+
+
+#ifdef __cplusplus
+}
+#endif	/* C++ */
+
+#endif /* regex.h */
+
+/*
+Local variables:
+make-backup-files: t
+version-control: t
+trim-versions-without-asking: nil
+End:
+*/

--- a/libr/asm/arch/nios/gnu/cgen-asm.c
+++ b/libr/asm/arch/nios/gnu/cgen-asm.c
@@ -1,0 +1,359 @@
+/* CGEN generic assembler support code.
+
+   Copyright (C) 1996, 1997, 1998 Free Software Foundation, Inc.
+
+   This file is part of the GNU Binutils and GDB, the GNU debugger.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2, or (at your option)
+   any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+
+#include "sysdep.h"
+#include <stdio.h>
+#include <ctype.h>
+#include "ansidecl.h"
+#include "libiberty.h"
+#include "bfd.h"
+#include "symcat.h"
+#include "opcode/cgen.h"
+#include "opintl.h"
+
+/* Set the cgen_parse_operand_fn callback.  */
+
+void
+cgen_set_parse_operand_fn (cd, fn)
+     CGEN_CPU_DESC cd;
+     cgen_parse_operand_fn fn;
+{
+  cd->parse_operand_fn = fn;
+}
+
+/* Called whenever starting to parse an insn.  */
+
+void
+cgen_init_parse_operand (cd)
+     CGEN_CPU_DESC cd;
+{
+  /* This tells the callback to re-initialize.  */
+  (void) (* cd->parse_operand_fn)
+    (cd, CGEN_PARSE_OPERAND_INIT, NULL, 0, 0, NULL, NULL);
+}
+
+/* Subroutine of build_asm_hash_table to add INSNS to the hash table.
+
+   COUNT is the number of elements in INSNS.
+   ENTSIZE is sizeof (CGEN_IBASE) for the target.
+   ??? No longer used but leave in for now.
+   HTABLE points to the hash table.
+   HENTBUF is a pointer to sufficiently large buffer of hash entries.
+   The result is a pointer to the next entry to use.
+
+   The table is scanned backwards as additions are made to the front of the
+   list and we want earlier ones to be prefered.  */
+
+static CGEN_INSN_LIST *
+hash_insn_array (cd, insns, count, entsize, htable, hentbuf)
+     CGEN_CPU_DESC cd;
+     const CGEN_INSN *insns;
+     int count;
+     int entsize;
+     CGEN_INSN_LIST **htable;
+     CGEN_INSN_LIST *hentbuf;
+{
+  int i;
+
+  for (i = count - 1; i >= 0; --i, ++hentbuf)
+    {
+      unsigned int hash;
+      const CGEN_INSN *insn = &insns[i];
+
+      if (! (* cd->asm_hash_p) (insn))
+	continue;
+      hash = (* cd->asm_hash) (CGEN_INSN_MNEMONIC (insn));
+      hentbuf->next = htable[hash];
+      hentbuf->insn = insn;
+      htable[hash] = hentbuf;
+    }
+
+  return hentbuf;
+}
+
+/* Subroutine of build_asm_hash_table to add INSNS to the hash table.
+   This function is identical to hash_insn_array except the insns are
+   in a list.  */
+
+static CGEN_INSN_LIST *
+hash_insn_list (cd, insns, htable, hentbuf)
+     CGEN_CPU_DESC cd;
+     const CGEN_INSN_LIST *insns;
+     CGEN_INSN_LIST **htable;
+     CGEN_INSN_LIST *hentbuf;
+{
+  const CGEN_INSN_LIST *ilist;
+
+  for (ilist = insns; ilist != NULL; ilist = ilist->next, ++ hentbuf)
+    {
+      unsigned int hash;
+
+      if (! (* cd->asm_hash_p) (ilist->insn))
+	continue;
+      hash = (* cd->asm_hash) (CGEN_INSN_MNEMONIC (ilist->insn));
+      hentbuf->next = htable[hash];
+      hentbuf->insn = ilist->insn;
+      htable[hash] = hentbuf;
+    }
+
+  return hentbuf;
+}
+
+/* Build the assembler instruction hash table.  */
+
+static void
+build_asm_hash_table (cd)
+     CGEN_CPU_DESC cd;
+{
+  int count = cgen_insn_count (cd) + cgen_macro_insn_count (cd);
+  CGEN_INSN_TABLE *insn_table = &cd->insn_table;
+  CGEN_INSN_TABLE *macro_insn_table = &cd->macro_insn_table;
+  unsigned int hash_size = cd->asm_hash_size;
+  CGEN_INSN_LIST *hash_entry_buf;
+  CGEN_INSN_LIST **asm_hash_table;
+  CGEN_INSN_LIST *asm_hash_table_entries;
+
+  /* The space allocated for the hash table consists of two parts:
+     the hash table and the hash lists.  */
+
+  asm_hash_table = (CGEN_INSN_LIST **)
+    xmalloc (hash_size * sizeof (CGEN_INSN_LIST *));
+  memset (asm_hash_table, 0, hash_size * sizeof (CGEN_INSN_LIST *));
+  asm_hash_table_entries = hash_entry_buf = (CGEN_INSN_LIST *)
+    xmalloc (count * sizeof (CGEN_INSN_LIST));
+
+  /* Add compiled in insns.
+     Don't include the first one as it is a reserved entry.  */
+  /* ??? It was the end of all hash chains, and also the special
+     "invalid insn" marker.  May be able to do it differently now.  */
+
+  hash_entry_buf = hash_insn_array (cd,
+				    insn_table->init_entries + 1,
+				    insn_table->num_init_entries - 1,
+				    insn_table->entry_size,
+				    asm_hash_table, hash_entry_buf);
+
+  /* Add compiled in macro-insns.  */
+
+  hash_entry_buf = hash_insn_array (cd, macro_insn_table->init_entries,
+				    macro_insn_table->num_init_entries,
+				    macro_insn_table->entry_size,
+				    asm_hash_table, hash_entry_buf);
+
+  /* Add runtime added insns.
+     Later added insns will be prefered over earlier ones.  */
+
+  hash_entry_buf = hash_insn_list (cd, insn_table->new_entries,
+				   asm_hash_table, hash_entry_buf);
+
+  /* Add runtime added macro-insns.  */
+
+  hash_insn_list (cd, macro_insn_table->new_entries,
+		  asm_hash_table, hash_entry_buf);
+
+  cd->asm_hash_table = asm_hash_table;
+  cd->asm_hash_table_entries = asm_hash_table_entries;
+}
+
+/* Return the first entry in the hash list for INSN.  */
+
+CGEN_INSN_LIST *
+cgen_asm_lookup_insn (cd, insn)
+     CGEN_CPU_DESC cd;
+     const char *insn;
+{
+  unsigned int hash;
+
+  if (cd->asm_hash_table == NULL)
+    build_asm_hash_table (cd);
+
+  hash = (* cd->asm_hash) (insn);
+  return cd->asm_hash_table[hash];
+}
+
+/* Keyword parser.
+   The result is NULL upon success or an error message.
+   If successful, *STRP is updated to point passed the keyword.
+
+   ??? At present we have a static notion of how to pick out a keyword.
+   Later we can allow a target to customize this if necessary [say by
+   recording something in the keyword table].  */
+
+const char *
+cgen_parse_keyword (cd, strp, keyword_table, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     CGEN_KEYWORD *keyword_table;
+     long *valuep;
+{
+  const CGEN_KEYWORD_ENTRY *ke;
+  char buf[256];
+  const char *p,*start;
+
+  p = start = *strp;
+
+  /* Allow any first character.
+     Note that this allows recognizing ",a" for the annul flag in sparc
+     even though "," is subsequently not a valid keyword char.  */
+  if (*p)
+    ++p;
+
+  /* Now allow letters, digits, and _.  */
+  while (((p - start) < (int) sizeof (buf))
+	 && (isalnum ((unsigned char) *p) || *p == '_'))
+    ++p;
+
+  if (p - start >= (int) sizeof (buf))
+    return _("unrecognized keyword/register name");
+
+  memcpy (buf, start, p - start);
+  buf[p - start] = 0;
+
+  ke = cgen_keyword_lookup_name (keyword_table, buf);
+
+  if (ke != NULL)
+    {
+      *valuep = ke->value;
+      /* Don't advance pointer if we recognized the null keyword.  */
+      if (ke->name[0] != 0)
+	*strp = p;
+      return NULL;
+    }
+
+  return "unrecognized keyword/register name";
+}
+
+/* Parse a small signed integer parser.
+   ??? VALUEP is not a bfd_vma * on purpose, though this is confusing.
+   Note that if the caller expects a bfd_vma result, it should call
+   cgen_parse_address.  */
+
+const char *
+cgen_parse_signed_integer (cd, strp, opindex, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     int opindex;
+     long *valuep;
+{
+  bfd_vma value;
+  enum cgen_parse_operand_result result;
+  const char *errmsg;
+
+  errmsg = (* cd->parse_operand_fn)
+    (cd, CGEN_PARSE_OPERAND_INTEGER, strp, opindex, BFD_RELOC_NONE,
+     &result, &value);
+  /* FIXME: Examine `result'.  */
+  if (!errmsg)
+    *valuep = value;
+  return errmsg;
+}
+
+/* Parse a small unsigned integer parser.
+   ??? VALUEP is not a bfd_vma * on purpose, though this is confusing.
+   Note that if the caller expects a bfd_vma result, it should call
+   cgen_parse_address.  */
+
+const char *
+cgen_parse_unsigned_integer (cd, strp, opindex, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     int opindex;
+     unsigned long *valuep;
+{
+  bfd_vma value;
+  enum cgen_parse_operand_result result;
+  const char *errmsg;
+
+  errmsg = (* cd->parse_operand_fn)
+    (cd, CGEN_PARSE_OPERAND_INTEGER, strp, opindex, BFD_RELOC_NONE,
+     &result, &value);
+  /* FIXME: Examine `result'.  */
+  if (!errmsg)
+    *valuep = value;
+  return errmsg;
+}
+
+/* Address parser.  */
+
+const char *
+cgen_parse_address (cd, strp, opindex, opinfo, resultp, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     int opindex;
+     int opinfo;
+     enum cgen_parse_operand_result *resultp;
+     bfd_vma *valuep;
+{
+  bfd_vma value;
+  enum cgen_parse_operand_result result_type;
+  const char *errmsg;
+
+  errmsg = (* cd->parse_operand_fn)
+    (cd, CGEN_PARSE_OPERAND_ADDRESS, strp, opindex, opinfo,
+     &result_type, &value);
+  /* FIXME: Examine `result'.  */
+  if (!errmsg)
+    {
+      if (resultp != NULL)
+	*resultp = result_type;
+      *valuep = value;
+    }
+  return errmsg;
+}
+
+/* Signed integer validation routine.  */
+
+const char *
+cgen_validate_signed_integer (value, min, max)
+     long value, min, max;
+{
+  if (value < min || value > max)
+    {
+      static char buf[100];
+
+      /* xgettext:c-format */
+      sprintf (buf, _("operand out of range (%ld not between %ld and %ld)"),
+		      value, min, max);
+      return buf;
+    }
+
+  return NULL;
+}
+
+/* Unsigned integer validation routine.
+   Supplying `min' here may seem unnecessary, but we also want to handle
+   cases where min != 0 (and max > LONG_MAX).  */
+
+const char *
+cgen_validate_unsigned_integer (value, min, max)
+     unsigned long value, min, max;
+{
+  if (value < min || value > max)
+    {
+      static char buf[100];
+
+      /* xgettext:c-format */
+      sprintf (buf, _("operand out of range (%lu not between %lu and %lu)"),
+	       value, min, max);
+      return buf;
+    }
+
+  return NULL;
+}

--- a/libr/asm/arch/nios/gnu/cgen-bitset.c
+++ b/libr/asm/arch/nios/gnu/cgen-bitset.c
@@ -1,0 +1,172 @@
+/* CGEN generic opcode support.
+   Copyright (C) 2002-2018 Free Software Foundation, Inc.
+
+   This file is part of libopcodes.
+
+   This library is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3, or (at your option)
+   any later version.
+
+   It is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+   License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.  */
+
+/* Functions for manipulating CGEN_BITSET.  */
+
+#include "libiberty.h"
+#include "cgen/bitset.h"
+#include <string.h>
+
+/* Create a bit mask.  */
+
+CGEN_BITSET *
+cgen_bitset_create (unsigned bit_count)
+{
+  CGEN_BITSET * mask = xmalloc (sizeof (* mask));
+  cgen_bitset_init (mask, bit_count);
+  return mask;
+}
+
+/* Initialize an existing bit mask.  */
+
+void
+cgen_bitset_init (CGEN_BITSET * mask, unsigned bit_count)
+{
+  if (! mask)
+    return;
+  mask->length = (bit_count / 8) + 1;
+  mask->bits = xmalloc (mask->length);
+  cgen_bitset_clear (mask);
+}
+
+/* Clear the bits of a bit mask.  */
+
+void
+cgen_bitset_clear (CGEN_BITSET * mask)
+{
+  unsigned i;
+
+  if (! mask)
+    return;
+
+  for (i = 0; i < mask->length; ++i)
+    mask->bits[i] = 0;
+}
+
+/* Add a bit to a bit mask.  */
+
+void
+cgen_bitset_add (CGEN_BITSET * mask, unsigned bit_num)
+{
+  int byte_ix, bit_ix;
+  int bit_mask;
+
+  if (! mask)
+    return;
+  byte_ix = bit_num / 8;
+  bit_ix = bit_num % 8;
+  bit_mask = 1 << (7 - bit_ix);
+  mask->bits[byte_ix] |= bit_mask;
+}
+
+/* Set a bit mask.  */
+
+void
+cgen_bitset_set (CGEN_BITSET * mask, unsigned bit_num)
+{
+  if (! mask)
+    return;
+  cgen_bitset_clear (mask);
+  cgen_bitset_add (mask, bit_num);
+}
+
+/* Test for a bit in a bit mask.
+   Returns 1 if the bit is found  */
+
+int
+cgen_bitset_contains (CGEN_BITSET * mask, unsigned bit_num)
+{
+  int byte_ix, bit_ix;
+  int bit_mask;
+
+  if (! mask)
+    return 1; /* No bit restrictions.  */
+
+  byte_ix = bit_num / 8;
+  bit_ix = 7 - (bit_num % 8);
+  bit_mask = 1 << bit_ix;
+  return (mask->bits[byte_ix] & bit_mask) >> bit_ix;
+}
+
+/* Compare two bit masks for equality.
+   Returns 0 if they are equal.  */
+
+int
+cgen_bitset_compare (CGEN_BITSET * mask1, CGEN_BITSET * mask2)
+{
+  if (mask1 == mask2)
+    return 0;
+  if (! mask1 || ! mask2)
+    return 1;
+  if (mask1->length != mask2->length)
+    return 1;
+  return memcmp (mask1->bits, mask2->bits, mask1->length);
+}
+
+/* Test two bit masks for common bits.
+   Returns 1 if a common bit is found.  */
+
+int
+cgen_bitset_intersect_p (CGEN_BITSET * mask1, CGEN_BITSET * mask2)
+{
+  unsigned i, limit;
+
+  if (mask1 == mask2)
+    return 1;
+  if (! mask1 || ! mask2)
+    return 0;
+  limit = mask1->length < mask2->length ? mask1->length : mask2->length;
+
+  for (i = 0; i < limit; ++i)
+    if ((mask1->bits[i] & mask2->bits[i]))
+      return 1;
+
+  return 0;
+}
+
+/* Make a copy of a bit mask.  */
+
+CGEN_BITSET *
+cgen_bitset_copy (CGEN_BITSET * mask)
+{
+  CGEN_BITSET* newmask;
+
+  if (! mask)
+    return NULL;
+  newmask = cgen_bitset_create ((mask->length * 8) - 1);
+  memcpy (newmask->bits, mask->bits, mask->length);
+  return newmask;
+}
+
+/* Combine two bit masks.  */
+
+void
+cgen_bitset_union (CGEN_BITSET * mask1, CGEN_BITSET * mask2,
+		   CGEN_BITSET * result)
+{
+  unsigned i;
+
+  if (! mask1 || ! mask2 || ! result
+      || mask1->length != mask2->length
+      || mask1->length != result->length)
+    return;
+
+  for (i = 0; i < result->length; ++i)
+    result->bits[i] = mask1->bits[i] | mask2->bits[i];
+}

--- a/libr/asm/arch/nios/gnu/cgen-dis.c
+++ b/libr/asm/arch/nios/gnu/cgen-dis.c
@@ -1,0 +1,226 @@
+/* CGEN generic disassembler support code.
+
+   Copyright (C) 1996, 1997, 1998, 1999 Free Software Foundation, Inc.
+
+   This file is part of the GNU Binutils and GDB, the GNU debugger.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2, or (at your option)
+   any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+
+#include "sysdep.h"
+#include <stdio.h>
+#include "ansidecl.h"
+#include "libiberty.h"
+#include "bfd.h"
+#include "symcat.h"
+#include "opcode/cgen.h"
+
+/* Subroutine of build_dis_hash_table to add INSNS to the hash table.
+
+   COUNT is the number of elements in INSNS.
+   ENTSIZE is sizeof (CGEN_IBASE) for the target.
+   ??? No longer used but leave in for now.
+   HTABLE points to the hash table.
+   HENTBUF is a pointer to sufficiently large buffer of hash entries.
+   The result is a pointer to the next entry to use.
+
+   The table is scanned backwards as additions are made to the front of the
+   list and we want earlier ones to be prefered.  */
+
+static CGEN_INSN_LIST *
+hash_insn_array (cd, insns, count, entsize, htable, hentbuf)
+     CGEN_CPU_DESC cd;
+     const CGEN_INSN * insns;
+     int count;
+     int entsize;
+     CGEN_INSN_LIST ** htable;
+     CGEN_INSN_LIST * hentbuf;
+{
+  int big_p = CGEN_CPU_ENDIAN (cd) == CGEN_ENDIAN_BIG;
+  int i;
+
+  for (i = count - 1; i >= 0; --i, ++hentbuf)
+    {
+      unsigned int hash;
+      char buf [4];
+      unsigned long value;
+      const CGEN_INSN *insn = &insns[i];
+
+      if (! (* cd->dis_hash_p) (insn))
+	continue;
+
+      /* We don't know whether the target uses the buffer or the base insn
+	 to hash on, so set both up.  */
+
+      value = CGEN_INSN_BASE_VALUE (insn);
+      switch (CGEN_INSN_MASK_BITSIZE (insn))
+	{
+	case 8:
+	  buf[0] = value;
+	  break;
+	case 16:
+	  if (big_p)
+	    bfd_putb16 ((bfd_vma) value, buf);
+	  else
+	    bfd_putl16 ((bfd_vma) value, buf);
+	  break;
+	case 32:
+	  if (big_p)
+	    bfd_putb32 ((bfd_vma) value, buf);
+	  else
+	    bfd_putl32 ((bfd_vma) value, buf);
+	  break;
+	default:
+	  abort ();
+	}
+
+      hash = (* cd->dis_hash) (buf, value);
+      hentbuf->next = htable[hash];
+      hentbuf->insn = insn;
+      htable[hash] = hentbuf;
+    }
+
+  return hentbuf;
+}
+
+/* Subroutine of build_dis_hash_table to add INSNS to the hash table.
+   This function is identical to hash_insn_array except the insns are
+   in a list.  */
+
+static CGEN_INSN_LIST *
+hash_insn_list (cd, insns, htable, hentbuf)
+     CGEN_CPU_DESC cd;
+     const CGEN_INSN_LIST *insns;
+     CGEN_INSN_LIST **htable;
+     CGEN_INSN_LIST *hentbuf;
+{
+  int big_p = CGEN_CPU_ENDIAN (cd) == CGEN_ENDIAN_BIG;
+  const CGEN_INSN_LIST *ilist;
+
+  for (ilist = insns; ilist != NULL; ilist = ilist->next, ++ hentbuf)
+    {
+      unsigned int hash;
+      char buf[4];
+      unsigned long value;
+
+      if (! (* cd->dis_hash_p) (ilist->insn))
+	continue;
+
+      /* We don't know whether the target uses the buffer or the base insn
+	 to hash on, so set both up.  */
+
+      value = CGEN_INSN_BASE_VALUE (ilist->insn);
+      switch (CGEN_INSN_MASK_BITSIZE (ilist->insn))
+	{
+	case 8:
+	  buf[0] = value;
+	  break;
+	case 16:
+	  if (big_p)
+	    bfd_putb16 ((bfd_vma) value, buf);
+	  else
+	    bfd_putl16 ((bfd_vma) value, buf);
+	  break;
+	case 32:
+	  if (big_p)
+	    bfd_putb32 ((bfd_vma) value, buf);
+	  else
+	    bfd_putl32 ((bfd_vma) value, buf);
+	  break;
+	default:
+	  abort ();
+	}
+
+      hash = (* cd->dis_hash) (buf, value);
+      hentbuf->next = htable [hash];
+      hentbuf->insn = ilist->insn;
+      htable [hash] = hentbuf;
+    }
+
+  return hentbuf;
+}
+
+/* Build the disassembler instruction hash table.  */
+
+static void
+build_dis_hash_table (cd)
+     CGEN_CPU_DESC cd;
+{
+  int count = cgen_insn_count (cd) + cgen_macro_insn_count (cd);
+  CGEN_INSN_TABLE *insn_table = & cd->insn_table;
+  CGEN_INSN_TABLE *macro_insn_table = & cd->macro_insn_table;
+  unsigned int hash_size = cd->dis_hash_size;
+  CGEN_INSN_LIST *hash_entry_buf;
+  CGEN_INSN_LIST **dis_hash_table;
+  CGEN_INSN_LIST *dis_hash_table_entries;
+
+  /* The space allocated for the hash table consists of two parts:
+     the hash table and the hash lists.  */
+
+  dis_hash_table = (CGEN_INSN_LIST **)
+    xmalloc (hash_size * sizeof (CGEN_INSN_LIST *));
+  memset (dis_hash_table, 0, hash_size * sizeof (CGEN_INSN_LIST *));
+  dis_hash_table_entries = hash_entry_buf = (CGEN_INSN_LIST *)
+    xmalloc (count * sizeof (CGEN_INSN_LIST));
+
+  /* Add compiled in insns.
+     Don't include the first one as it is a reserved entry.  */
+  /* ??? It was the end of all hash chains, and also the special
+     "invalid insn" marker.  May be able to do it differently now.  */
+
+  hash_entry_buf = hash_insn_array (cd,
+				    insn_table->init_entries + 1,
+				    insn_table->num_init_entries - 1,
+				    insn_table->entry_size,
+				    dis_hash_table, hash_entry_buf);
+
+  /* Add compiled in macro-insns.  */
+
+  hash_entry_buf = hash_insn_array (cd, macro_insn_table->init_entries,
+				    macro_insn_table->num_init_entries,
+				    macro_insn_table->entry_size,
+				    dis_hash_table, hash_entry_buf);
+
+  /* Add runtime added insns.
+     Later added insns will be prefered over earlier ones.  */
+
+  hash_entry_buf = hash_insn_list (cd, insn_table->new_entries,
+				   dis_hash_table, hash_entry_buf);
+
+  /* Add runtime added macro-insns.  */
+
+  hash_insn_list (cd, macro_insn_table->new_entries,
+		  dis_hash_table, hash_entry_buf);
+
+  cd->dis_hash_table = dis_hash_table;
+  cd->dis_hash_table_entries = dis_hash_table_entries;
+}
+
+/* Return the first entry in the hash list for INSN.  */
+
+CGEN_INSN_LIST *
+cgen_dis_lookup_insn (cd, buf, value)
+     CGEN_CPU_DESC cd;
+     const char * buf;
+     CGEN_INSN_INT value;
+{
+  unsigned int hash;
+
+  if (cd->dis_hash_table == NULL)
+    build_dis_hash_table (cd);
+
+  hash = (* cd->dis_hash) (buf, value);
+
+  return cd->dis_hash_table[hash];
+}

--- a/libr/asm/arch/nios/gnu/cgen-opc.c
+++ b/libr/asm/arch/nios/gnu/cgen-opc.c
@@ -1,0 +1,621 @@
+/* CGEN generic opcode support.
+
+   Copyright (C) 1996, 1997, 1998, 1999, 2000 Free Software Foundation, Inc.
+
+   This file is part of the GNU Binutils and GDB, the GNU debugger.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2, or (at your option)
+   any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+
+#include "sysdep.h"
+#include <ctype.h>
+#include <stdio.h>
+#include "ansidecl.h"
+#include "libiberty.h"
+#include "bfd.h"
+#include "symcat.h"
+#include "opcode/cgen.h"
+
+static unsigned int hash_keyword_name
+  PARAMS ((const CGEN_KEYWORD *, const char *, int));
+static unsigned int hash_keyword_value
+  PARAMS ((const CGEN_KEYWORD *, unsigned int));
+static void build_keyword_hash_tables
+  PARAMS ((CGEN_KEYWORD *));
+
+/* Return number of hash table entries to use for N elements.  */
+#define KEYWORD_HASH_SIZE(n) ((n) <= 31 ? 17 : 31)
+
+/* Look up *NAMEP in the keyword table KT.
+   The result is the keyword entry or NULL if not found.  */
+
+const CGEN_KEYWORD_ENTRY *
+cgen_keyword_lookup_name (kt, name)
+     CGEN_KEYWORD *kt;
+     const char *name;
+{
+  const CGEN_KEYWORD_ENTRY *ke;
+  const char *p,*n;
+
+  if (kt->name_hash_table == NULL)
+    build_keyword_hash_tables (kt);
+
+  ke = kt->name_hash_table[hash_keyword_name (kt, name, 0)];
+
+  /* We do case insensitive comparisons.
+     If that ever becomes a problem, add an attribute that denotes
+     "do case sensitive comparisons".  */
+
+  while (ke != NULL)
+    {
+      n = name;
+      p = ke->name;
+
+      while (*p
+	     && (*p == *n
+		 || (isalpha ((unsigned char) *p)
+		     && (tolower ((unsigned char) *p)
+			 == tolower ((unsigned char) *n)))))
+	++n, ++p;
+
+      if (!*p && !*n)
+	return ke;
+
+      ke = ke->next_name;
+    }
+
+  if (kt->null_entry)
+    return kt->null_entry;
+  return NULL;
+}
+
+/* Look up VALUE in the keyword table KT.
+   The result is the keyword entry or NULL if not found.  */
+
+const CGEN_KEYWORD_ENTRY *
+cgen_keyword_lookup_value (kt, value)
+     CGEN_KEYWORD *kt;
+     int value;
+{
+  const CGEN_KEYWORD_ENTRY *ke;
+
+  if (kt->name_hash_table == NULL)
+    build_keyword_hash_tables (kt);
+
+  ke = kt->value_hash_table[hash_keyword_value (kt, value)];
+
+  while (ke != NULL)
+    {
+      if (value == ke->value)
+	return ke;
+      ke = ke->next_value;
+    }
+
+  return NULL;
+}
+
+/* Add an entry to a keyword table.  */
+
+void
+cgen_keyword_add (kt, ke)
+     CGEN_KEYWORD *kt;
+     CGEN_KEYWORD_ENTRY *ke;
+{
+  unsigned int hash;
+
+  if (kt->name_hash_table == NULL)
+    build_keyword_hash_tables (kt);
+
+  hash = hash_keyword_name (kt, ke->name, 0);
+  ke->next_name = kt->name_hash_table[hash];
+  kt->name_hash_table[hash] = ke;
+
+  hash = hash_keyword_value (kt, ke->value);
+  ke->next_value = kt->value_hash_table[hash];
+  kt->value_hash_table[hash] = ke;
+
+  if (ke->name[0] == 0)
+    kt->null_entry = ke;
+}
+
+/* FIXME: Need function to return count of keywords.  */
+
+/* Initialize a keyword table search.
+   SPEC is a specification of what to search for.
+   A value of NULL means to find every keyword.
+   Currently NULL is the only acceptable value [further specification
+   deferred].
+   The result is an opaque data item used to record the search status.
+   It is passed to each call to cgen_keyword_search_next.  */
+
+CGEN_KEYWORD_SEARCH
+cgen_keyword_search_init (kt, spec)
+     CGEN_KEYWORD *kt;
+     const char *spec;
+{
+  CGEN_KEYWORD_SEARCH search;
+
+  /* FIXME: Need to specify format of PARAMS.  */
+  if (spec != NULL)
+    abort ();
+
+  if (kt->name_hash_table == NULL)
+    build_keyword_hash_tables (kt);
+
+  search.table = kt;
+  search.spec = spec;
+  search.current_hash = 0;
+  search.current_entry = NULL;
+  return search;
+}
+
+/* Return the next keyword specified by SEARCH.
+   The result is the next entry or NULL if there are no more.  */
+
+const CGEN_KEYWORD_ENTRY *
+cgen_keyword_search_next (search)
+     CGEN_KEYWORD_SEARCH *search;
+{
+  /* Has search finished?  */
+  if (search->current_hash == search->table->hash_table_size)
+    return NULL;
+
+  /* Search in progress?  */
+  if (search->current_entry != NULL
+      /* Anything left on this hash chain?  */
+      && search->current_entry->next_name != NULL)
+    {
+      search->current_entry = search->current_entry->next_name;
+      return search->current_entry;
+    }
+
+  /* Move to next hash chain [unless we haven't started yet].  */
+  if (search->current_entry != NULL)
+    ++search->current_hash;
+
+  while (search->current_hash < search->table->hash_table_size)
+    {
+      search->current_entry = search->table->name_hash_table[search->current_hash];
+      if (search->current_entry != NULL)
+	return search->current_entry;
+      ++search->current_hash;
+    }
+
+  return NULL;
+}
+
+/* Return first entry in hash chain for NAME.
+   If CASE_SENSITIVE_P is non-zero, return a case sensitive hash.  */
+
+static unsigned int
+hash_keyword_name (kt, name, case_sensitive_p)
+     const CGEN_KEYWORD *kt;
+     const char *name;
+     int case_sensitive_p;
+{
+  unsigned int hash;
+
+  if (case_sensitive_p)
+    for (hash = 0; *name; ++name)
+      hash = (hash * 97) + (unsigned char) *name;
+  else
+    for (hash = 0; *name; ++name)
+      hash = (hash * 97) + (unsigned char) tolower (*name);
+  return hash % kt->hash_table_size;
+}
+
+/* Return first entry in hash chain for VALUE.  */
+
+static unsigned int
+hash_keyword_value (kt, value)
+     const CGEN_KEYWORD *kt;
+     unsigned int value;
+{
+  return value % kt->hash_table_size;
+}
+
+/* Build a keyword table's hash tables.
+   We probably needn't build the value hash table for the assembler when
+   we're using the disassembler, but we keep things simple.  */
+
+static void
+build_keyword_hash_tables (kt)
+     CGEN_KEYWORD *kt;
+{
+  int i;
+  /* Use the number of compiled in entries as an estimate for the
+     typical sized table [not too many added at runtime].  */
+  unsigned int size = KEYWORD_HASH_SIZE (kt->num_init_entries);
+
+  kt->hash_table_size = size;
+  kt->name_hash_table = (CGEN_KEYWORD_ENTRY **)
+    xmalloc (size * sizeof (CGEN_KEYWORD_ENTRY *));
+  memset (kt->name_hash_table, 0, size * sizeof (CGEN_KEYWORD_ENTRY *));
+  kt->value_hash_table = (CGEN_KEYWORD_ENTRY **)
+    xmalloc (size * sizeof (CGEN_KEYWORD_ENTRY *));
+  memset (kt->value_hash_table, 0, size * sizeof (CGEN_KEYWORD_ENTRY *));
+
+  /* The table is scanned backwards as we want keywords appearing earlier to
+     be prefered over later ones.  */
+  for (i = kt->num_init_entries - 1; i >= 0; --i)
+    cgen_keyword_add (kt, &kt->init_entries[i]);
+}
+
+/* Hardware support.  */
+
+/* Lookup a hardware element by its name.
+   Returns NULL if NAME is not supported by the currently selected
+   mach/isa.  */
+
+const CGEN_HW_ENTRY *
+cgen_hw_lookup_by_name (cd, name)
+     CGEN_CPU_DESC cd;
+     const char *name;
+{
+  int i;
+  const CGEN_HW_ENTRY **hw = cd->hw_table.entries;
+
+  for (i = 0; i < cd->hw_table.num_entries; ++i)
+    if (hw[i] && strcmp (name, hw[i]->name) == 0)
+      return hw[i];
+
+  return NULL;
+}
+
+/* Lookup a hardware element by its number.
+   Hardware elements are enumerated, however it may be possible to add some
+   at runtime, thus HWNUM is not an enum type but rather an int.
+   Returns NULL if HWNUM is not supported by the currently selected mach.  */
+
+const CGEN_HW_ENTRY *
+cgen_hw_lookup_by_num (cd, hwnum)
+     CGEN_CPU_DESC cd;
+     int hwnum;
+{
+  int i;
+  const CGEN_HW_ENTRY **hw = cd->hw_table.entries;
+
+  /* ??? This can be speeded up.  */
+  for (i = 0; i < cd->hw_table.num_entries; ++i)
+    if (hw[i] && hwnum == hw[i]->type)
+      return hw[i];
+
+  return NULL;
+}
+
+/* Operand support.  */
+
+/* Lookup an operand by its name.
+   Returns NULL if NAME is not supported by the currently selected
+   mach/isa.  */
+
+const CGEN_OPERAND *
+cgen_operand_lookup_by_name (cd, name)
+     CGEN_CPU_DESC cd;
+     const char *name;
+{
+  int i;
+  const CGEN_OPERAND **op = cd->operand_table.entries;
+
+  for (i = 0; i < cd->operand_table.num_entries; ++i)
+    if (op[i] && strcmp (name, op[i]->name) == 0)
+      return op[i];
+
+  return NULL;
+}
+
+/* Lookup an operand by its number.
+   Operands are enumerated, however it may be possible to add some
+   at runtime, thus OPNUM is not an enum type but rather an int.
+   Returns NULL if OPNUM is not supported by the currently selected
+   mach/isa.  */
+
+const CGEN_OPERAND *
+cgen_operand_lookup_by_num (cd, opnum)
+     CGEN_CPU_DESC cd;
+     int opnum;
+{
+  return cd->operand_table.entries[opnum];
+}
+
+/* Instruction support.  */
+
+/* Return number of instructions.  This includes any added at runtime.  */
+
+int
+cgen_insn_count (cd)
+     CGEN_CPU_DESC cd;
+{
+  int count = cd->insn_table.num_init_entries;
+  CGEN_INSN_LIST *rt_insns = cd->insn_table.new_entries;
+
+  for ( ; rt_insns != NULL; rt_insns = rt_insns->next)
+    ++count;
+
+  return count;
+}
+
+/* Return number of macro-instructions.
+   This includes any added at runtime.  */
+
+int
+cgen_macro_insn_count (cd)
+     CGEN_CPU_DESC cd;
+{
+  int count = cd->macro_insn_table.num_init_entries;
+  CGEN_INSN_LIST *rt_insns = cd->macro_insn_table.new_entries;
+
+  for ( ; rt_insns != NULL; rt_insns = rt_insns->next)
+    ++count;
+
+  return count;
+}
+
+/* Cover function to read and properly byteswap an insn value.  */
+
+CGEN_INSN_INT
+cgen_get_insn_value (cd, buf, length)
+     CGEN_CPU_DESC cd;
+     unsigned char *buf;
+     int length;
+{
+  CGEN_INSN_INT value;
+
+  switch (length)
+    {
+    case 8:
+      value = *buf;
+      break;
+    case 16:
+      if (cd->insn_endian == CGEN_ENDIAN_BIG)
+	value = bfd_getb16 (buf);
+      else
+	value = bfd_getl16 (buf);
+      break;
+    case 32:
+      if (cd->insn_endian == CGEN_ENDIAN_BIG)
+	value = bfd_getb32 (buf);
+      else
+	value = bfd_getl32 (buf);
+      break;
+    default:
+      abort ();
+    }
+
+  return value;
+}
+
+/* Cover function to store an insn value properly byteswapped.  */
+
+void
+cgen_put_insn_value (cd, buf, length, value)
+     CGEN_CPU_DESC cd;
+     unsigned char *buf;
+     int length;
+     CGEN_INSN_INT value;
+{
+  switch (length)
+    {
+    case 8:
+      buf[0] = value;
+      break;
+    case 16:
+      if (cd->insn_endian == CGEN_ENDIAN_BIG)
+	bfd_putb16 (value, buf);
+      else
+	bfd_putl16 (value, buf);
+      break;
+    case 32:
+      if (cd->insn_endian == CGEN_ENDIAN_BIG)
+	bfd_putb32 (value, buf);
+      else
+	bfd_putl32 (value, buf);
+      break;
+    default:
+      abort ();
+    }
+}
+
+/* Look up instruction INSN_*_VALUE and extract its fields.
+   INSN_INT_VALUE is used if CGEN_INT_INSN_P.
+   Otherwise INSN_BYTES_VALUE is used.
+   INSN, if non-null, is the insn table entry.
+   Otherwise INSN_*_VALUE is examined to compute it.
+   LENGTH is the bit length of INSN_*_VALUE if known, otherwise 0.
+   0 is only valid if `insn == NULL && ! CGEN_INT_INSN_P'.
+   If INSN != NULL, LENGTH must be valid.
+   ALIAS_P is non-zero if alias insns are to be included in the search.
+
+   The result is a pointer to the insn table entry, or NULL if the instruction
+   wasn't recognized.  */
+
+/* ??? Will need to be revisited for VLIW architectures.  */
+
+const CGEN_INSN *
+cgen_lookup_insn (cd, insn, insn_int_value, insn_bytes_value, length, fields,
+		  alias_p)
+     CGEN_CPU_DESC cd;
+     const CGEN_INSN *insn;
+     CGEN_INSN_INT insn_int_value;
+     /* ??? CGEN_INSN_BYTES would be a nice type name to use here.  */
+     unsigned char *insn_bytes_value;
+     int length;
+     CGEN_FIELDS *fields;
+     int alias_p;
+{
+  unsigned char *buf;
+  CGEN_INSN_INT base_insn;
+  CGEN_EXTRACT_INFO ex_info;
+  CGEN_EXTRACT_INFO *info;
+
+  if (cd->int_insn_p)
+    {
+      info = NULL;
+      buf = (unsigned char *) alloca (cd->max_insn_bitsize / 8);
+      cgen_put_insn_value (cd, buf, length, insn_int_value);
+      base_insn = insn_int_value;
+    }
+  else
+    {
+      info = &ex_info;
+      ex_info.dis_info = NULL;
+      ex_info.insn_bytes = insn_bytes_value;
+      ex_info.valid = -1;
+      buf = insn_bytes_value;
+      base_insn = cgen_get_insn_value (cd, buf, length);
+    }
+
+  if (!insn)
+    {
+      const CGEN_INSN_LIST *insn_list;
+
+      /* The instructions are stored in hash lists.
+	 Pick the first one and keep trying until we find the right one.  */
+
+      insn_list = cgen_dis_lookup_insn (cd, buf, base_insn);
+      while (insn_list != NULL)
+	{
+	  insn = insn_list->insn;
+
+	  if (alias_p
+	      /* FIXME: Ensure ALIAS attribute always has same index.  */
+	      || ! CGEN_INSN_ATTR_VALUE (insn, CGEN_INSN_ALIAS))
+	    {
+	      /* Basic bit mask must be correct.  */
+	      /* ??? May wish to allow target to defer this check until the
+		 extract handler.  */
+	      if ((base_insn & CGEN_INSN_BASE_MASK (insn))
+		  == CGEN_INSN_BASE_VALUE (insn))
+		{
+		  /* ??? 0 is passed for `pc' */
+		  int elength = CGEN_EXTRACT_FN (cd, insn)
+		    (cd, insn, info, base_insn, fields, (bfd_vma) 0);
+		  if (elength > 0)
+		    {
+		      /* sanity check */
+		      if (length != 0 && length != elength)
+			abort ();
+		      return insn;
+		    }
+		}
+	    }
+
+	  insn_list = insn_list->next;
+	}
+    }
+  else
+    {
+      /* Sanity check: can't pass an alias insn if ! alias_p.  */
+      if (! alias_p
+	  && CGEN_INSN_ATTR_VALUE (insn, CGEN_INSN_ALIAS))
+	abort ();
+      /* Sanity check: length must be correct.  */
+      if (length != CGEN_INSN_BITSIZE (insn))
+	abort ();
+
+      /* ??? 0 is passed for `pc' */
+      length = CGEN_EXTRACT_FN (cd, insn)
+	(cd, insn, info, base_insn, fields, (bfd_vma) 0);
+      /* Sanity check: must succeed.
+	 Could relax this later if it ever proves useful.  */
+      if (length == 0)
+	abort ();
+      return insn;
+    }
+
+  return NULL;
+}
+
+/* Fill in the operand instances used by INSN whose operands are FIELDS.
+   INDICES is a pointer to a buffer of MAX_OPERAND_INSTANCES ints to be filled
+   in.  */
+
+void
+cgen_get_insn_operands (cd, insn, fields, indices)
+     CGEN_CPU_DESC cd;
+     const CGEN_INSN *insn;
+     const CGEN_FIELDS *fields;
+     int *indices;
+{
+  const CGEN_OPINST *opinst;
+  int i;
+
+  if (insn->opinst == NULL)
+    abort ();
+  for (i = 0, opinst = insn->opinst; opinst->type != CGEN_OPINST_END; ++i, ++opinst)
+    {
+      enum cgen_operand_type op_type = opinst->op_type;
+      if (op_type == CGEN_OPERAND_NIL)
+	indices[i] = opinst->index;
+      else
+	indices[i] = (*cd->get_int_operand) (cd, op_type, fields);
+    }
+}
+
+/* Cover function to cgen_get_insn_operands when either INSN or FIELDS
+   isn't known.
+   The INSN, INSN_*_VALUE, and LENGTH arguments are passed to
+   cgen_lookup_insn unchanged.
+   INSN_INT_VALUE is used if CGEN_INT_INSN_P.
+   Otherwise INSN_BYTES_VALUE is used.
+
+   The result is the insn table entry or NULL if the instruction wasn't
+   recognized.  */
+
+const CGEN_INSN *
+cgen_lookup_get_insn_operands (cd, insn, insn_int_value, insn_bytes_value,
+			       length, indices, fields)
+     CGEN_CPU_DESC cd;
+     const CGEN_INSN *insn;
+     CGEN_INSN_INT insn_int_value;
+     /* ??? CGEN_INSN_BYTES would be a nice type name to use here.  */
+     unsigned char *insn_bytes_value;
+     int length;
+     int *indices;
+     CGEN_FIELDS *fields;
+{
+  /* Pass non-zero for ALIAS_P only if INSN != NULL.
+     If INSN == NULL, we want a real insn.  */
+  insn = cgen_lookup_insn (cd, insn, insn_int_value, insn_bytes_value,
+			   length, fields, insn != NULL);
+  if (! insn)
+    return NULL;
+
+  cgen_get_insn_operands (cd, insn, fields, indices);
+  return insn;
+}
+
+/* Allow signed overflow of instruction fields.  */
+void
+cgen_set_signed_overflow_ok (cd)
+     CGEN_CPU_DESC cd;
+{
+  cd->signed_overflow_ok_p = 1;
+}
+
+/* Generate an error message if a signed field in an instruction overflows.  */
+void
+cgen_clear_signed_overflow_ok (cd)
+     CGEN_CPU_DESC cd;
+{
+  cd->signed_overflow_ok_p = 0;
+}
+
+/* Will an error message be generated if a signed field in an instruction overflows ? */
+unsigned int
+cgen_signed_overflow_ok_p (cd)
+     CGEN_CPU_DESC cd;
+{
+  return cd->signed_overflow_ok_p;
+}

--- a/libr/asm/arch/nios/gnu/cpu-nios.c
+++ b/libr/asm/arch/nios/gnu/cpu-nios.c
@@ -17,9 +17,41 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
 
-#include "bfd.h"
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+//#include "bfd.h"
+#include "mybfd.h"
 #include "sysdep.h"
-#include "libbfd.h"
+//#include "libbfd.h"
+
+static int
+bfd_default_scan (info, string)
+     const bfd_arch_info_type *info;
+     const char *string;
+{
+        return 1;
+}
+
+static const bfd_arch_info_type *
+bfd_default_compatible (a, b)
+     const bfd_arch_info_type *a;
+     const bfd_arch_info_type *b;
+{
+  if (a->arch != b->arch)
+    return NULL;
+
+  if (a->bits_per_word != b->bits_per_word)
+    return NULL;
+
+  if (a->mach > b->mach) {
+    return a;
+  } else {
+    return b;
+  }
+}
+
 static const bfd_arch_info_type arch_info_struct[] =
 {
   {

--- a/libr/asm/arch/nios/gnu/cpu-nios.c
+++ b/libr/asm/arch/nios/gnu/cpu-nios.c
@@ -1,0 +1,57 @@
+/* BFD support for the NIOS processor.
+   Copyright (C) 1998 Free Software Foundation, Inc.
+
+This file is part of BFD, the Binary File Descriptor library.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+
+#include "bfd.h"
+#include "sysdep.h"
+#include "libbfd.h"
+static const bfd_arch_info_type arch_info_struct[] =
+{
+  {
+    32,				/* bits per word */
+    32,				/* bits per address */
+    8,				/* bits per byte */
+    bfd_arch_nios,		/* architecture */
+    bfd_mach_nios32,	/* machine */
+    "nios",			/* architecture name */
+    "nios32", 		/* printable name */
+    4,				/* section align power */
+    false,			/* the default ? */
+    bfd_default_compatible,	/* architecture comparison fn */
+    bfd_default_scan,		/* string to architecture convert fn */
+    NULL,                 	/* next in list */
+  }
+};
+
+const bfd_arch_info_type bfd_nios_arch =
+{
+  16,				/* bits per word */
+  16,				/* bits per address */
+  8,				/* bits per byte */
+  bfd_arch_nios,		/* architecture */
+  bfd_mach_nios16,		/* machine */
+  "nios",			/* architecture name */
+  "nios16", 		/* printable name */
+  4,				/* section align power */
+  true,				/* the default ? */
+  bfd_default_compatible,	/* architecture comparison fn */
+  bfd_default_scan,		/* string to architecture convert fn */
+  &arch_info_struct[0],		/* next in list */
+};
+
+

--- a/libr/asm/arch/nios/gnu/nios-asm.c
+++ b/libr/asm/arch/nios/gnu/nios-asm.c
@@ -1,0 +1,1125 @@
+/* Assembler interface for targets using CGEN. -*- C -*-
+   CGEN: Cpu tools GENerator
+
+THIS FILE IS MACHINE GENERATED WITH CGEN.
+- the resultant file is machine generated, cgen-asm.in isn't
+
+Copyright (C) 1996, 1997, 1998, 1999 Free Software Foundation, Inc.
+
+This file is part of the GNU Binutils and GDB, the GNU debugger.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation, Inc.,
+59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+
+/* ??? Eventually more and more of this stuff can go to cpu-independent files.
+   Keep that in mind.  */
+
+#include "sysdep.h"
+#include <ctype.h>
+#include <stdio.h>
+#include "ansidecl.h"
+#include "bfd.h"
+#include "symcat.h"
+#include "nios-desc.h"
+#include "nios-opc.h"
+#include "opintl.h"
+
+#undef min
+#define min(a,b) ((a) < (b) ? (a) : (b))
+#undef max
+#define max(a,b) ((a) > (b) ? (a) : (b))
+
+static const char * parse_insn_normal
+     PARAMS ((CGEN_CPU_DESC, const CGEN_INSN *, const char **, CGEN_FIELDS *));
+
+/* -- assembler routines inserted here */
+
+/* -- asm.c */
+/* Handle %lo(), %xlo().  */
+
+int nios_parsed_i11 = 0;
+int nios_Rbi5 = 0;
+
+/* The following is an internal routine to allow @h values to specify offsets.
+   The routine creates a temporary buffer with the string "sans" the @h specifier.
+   This allows the cgen_parse_address routine to correctly set any desired offset. */
+static const char *
+parse_h_address (cd, strp, at_h_pos, opindex, opinfo, resultp, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     char *at_h_pos;
+     int opindex;
+     int opinfo;
+     enum cgen_parse_operand_result *resultp;
+     bfd_vma *valuep;
+{
+  char buffer[200];
+  char *bufptr = buffer;
+  char **bufp = &bufptr;
+  int at_h_index = at_h_pos - *strp;
+  char *errmsg;
+
+  memcpy (buffer, *strp, at_h_index);
+  strcpy (buffer + at_h_index, *strp + at_h_index + 2);
+
+  errmsg = cgen_parse_address (cd, bufp, opindex, opinfo, resultp, valuep);
+
+  /* bump up real string pointer appropriately and account for the @h as well */
+  *strp += (bufptr - buffer) + 2;
+
+  return errmsg;
+} 
+
+
+static const char *
+parse_i5 (cd, strp, opindex, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     int opindex;
+     long *valuep;
+{
+  const char *errmsg;
+  enum cgen_parse_operand_result result_type;
+  bfd_vma value;
+
+  if (strncasecmp (*strp, "%lo(", 4) == 0)
+    {
+      *strp += 4;
+      if (**strp == '-' || isdigit(**strp))
+	{
+	  errmsg = cgen_parse_signed_integer (cd, strp, opindex, &value);
+	  if (**strp != ')')
+	    return _("missing ')'");
+	  ++*strp;
+	}
+      else 
+        {
+	  char *k = strchr (*strp, '@');
+	  if (k != NULL && k[1] == 'h')
+	    {
+	      errmsg = parse_h_address (cd, strp, k, opindex, BFD_RELOC_NIOS_H_LO5,
+					&result_type, &value);
+	      value >>= 1;
+	    }
+	  else
+	    {
+	      errmsg = cgen_parse_address (cd, strp, opindex, BFD_RELOC_NIOS_LO16_LO5,
+					   &result_type, &value);
+	    }
+	  if (**strp != ')')
+	    return _("missing ')'");
+	  ++*strp;
+	}
+      value &= 0x1f;
+      *valuep = value;
+      return errmsg;
+    }
+  else if (strncasecmp (*strp, "%xlo(", 5) == 0)
+    {
+      *strp += 5;
+      if (**strp == '-' || isdigit(**strp))
+	{
+	  errmsg = cgen_parse_signed_integer (cd, strp, opindex, &value);
+	  if (**strp != ')')
+	    return _("missing ')'");
+	  ++*strp;
+	}
+      else 
+        {
+	  char *k = strchr (*strp, '@');
+	  if (k != NULL && k[1] == 'h')
+	    {
+	      errmsg = parse_h_address (cd, strp, k, opindex, BFD_RELOC_NIOS_H_XLO5,
+				        &result_type, &value);
+	      value >>= 1;
+	    }
+	  else
+	    {
+	      errmsg = cgen_parse_address (cd, strp, opindex, BFD_RELOC_NIOS_HI16_LO5,
+					   &result_type, &value);
+	    }
+	  if (**strp != ')')
+	    return _("missing ')'");
+	  ++*strp;
+	}
+      value = ((value >> 16) & 0x1f);
+      *valuep = value;
+      return errmsg;
+    }
+
+  errmsg = cgen_parse_unsigned_integer (cd, strp, opindex, &value);
+  if (value > 0x1f)
+    return _("immediate value out of range");
+  *valuep = value;
+  return errmsg;
+}
+
+/* for STS8s */
+
+static const char *
+parse_i10 (cd, strp, opindex, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     int opindex;
+     long *valuep;
+{
+  const char *errmsg;
+  enum cgen_parse_operand_result result_type;
+  bfd_vma value;
+
+  errmsg = cgen_parse_unsigned_integer (cd, strp, opindex, &value);
+  if (value > 0x3ff)
+    return _("immediate value out of range");
+  *valuep = value;
+  return errmsg;
+}
+
+/* for STS16s */
+
+static const char *
+parse_i9 (cd, strp, opindex, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     int opindex;
+     long *valuep;
+{
+  const char *errmsg;
+  enum cgen_parse_operand_result result_type;
+  bfd_vma value;
+
+  errmsg = cgen_parse_unsigned_integer (cd, strp, opindex, &value);
+  if (value > 0x1ff)
+    return _("immediate value out of range");
+  *valuep = value;
+  return errmsg;
+}
+
+/* check dual mode instruction...could be register or immediate value */
+static const char *
+parse_Rbi5 (cd, strp, opindex, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     int opindex;
+     long *valuep;
+{
+  const char *errmsg;
+  enum cgen_parse_operand_result result_type;
+  bfd_vma value;
+  bfd_vma extra = 0;
+
+  nios_Rbi5 = NIOS_RBI5_IMMEDIATE;
+
+  if (strncasecmp (*strp, "%lo(", 4) == 0)
+    {
+      *strp += 4;
+      if (**strp == '-' || isdigit(**strp))
+	{
+	  errmsg = cgen_parse_signed_integer (cd, strp, opindex, &value);
+	  if (**strp != ')')
+	    return _("missing ')'");
+	  ++*strp;
+	}
+      else 
+        {
+	  char *k = strchr (*strp, '@');
+	  if (k != NULL && k[1] == 'h')
+	    {
+	      errmsg = parse_h_address (cd, strp, k, opindex, BFD_RELOC_NIOS_H_LO5,
+					&result_type, &value);
+	      value >>= 1;
+	    }
+	  else
+	    {
+	      errmsg = cgen_parse_address (cd, strp, opindex, BFD_RELOC_NIOS_LO16_LO5,
+					   &result_type, &value);
+	    }
+	  if (**strp != ')')
+	    return _("missing ')'");
+	  ++*strp;
+	}
+      value &= 0x1f;
+      *valuep = value;
+      return errmsg;
+    }
+  else if (strncasecmp (*strp, "%xlo(", 5) == 0)
+    {
+      *strp += 5;
+      if (**strp == '-' || isdigit(**strp))
+	{
+	  errmsg = cgen_parse_signed_integer (cd, strp, opindex, &value);
+	  if (**strp != ')')
+	    return _("missing ')'");
+	  ++*strp;
+	}
+      else 
+        {
+	  char *k = strchr (*strp, '@');
+	  if (k != NULL && k[1] == 'h')
+	    {
+	      errmsg = parse_h_address (cd, strp, k, opindex, BFD_RELOC_NIOS_H_XLO5,
+					   &result_type, &value);
+	      value >>= 1;
+	    }
+	  else
+	    {
+	      errmsg = cgen_parse_address (cd, strp, opindex, BFD_RELOC_NIOS_HI16_LO5,
+					   &result_type, &value);
+	    }
+	  if (**strp != ')')
+	    return _("missing ')'");
+	  ++*strp;
+	}
+      value = ((value >> 16) & 0x1f);
+      *valuep = value;
+      return errmsg;
+    }
+  else if (strncmp (*strp, "%r", 2) == 0 ||
+	   strncmp (*strp, "%g", 2) == 0)
+    {
+      *strp += 2;
+      nios_Rbi5 = NIOS_RBI5_REGISTER;
+    }
+  else if (strncmp (*strp, "%i", 2) == 0)
+    {
+      *strp += 2;
+      extra = 24;
+      nios_Rbi5 = NIOS_RBI5_REGISTER;
+    }
+  else if (strncmp (*strp, "%o", 2) == 0)
+    {
+      *strp += 2;
+      extra = 8;
+      nios_Rbi5 = NIOS_RBI5_REGISTER;
+    }
+  else if (strncmp (*strp, "%l", 2) == 0)
+    {
+      *strp += 2;
+      extra = 16;
+      nios_Rbi5 = NIOS_RBI5_REGISTER;
+    }
+  else if (strncmp (*strp, "%sp", 3) == 0)
+    {
+      *strp += 2;
+      *valuep = 14;
+      nios_Rbi5 = NIOS_RBI5_REGISTER;
+      return errmsg;
+    }
+
+  errmsg = cgen_parse_unsigned_integer (cd, strp, opindex, valuep);
+  *valuep += extra;
+
+  if (*valuep > 0x1f)
+    return _("immediate value out of range");
+  return errmsg;
+}
+
+/* Handle %hi(), %xhi().  */
+
+static const char *
+parse_i11 (cd, strp, opindex, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     int opindex;
+     unsigned long *valuep;
+{
+  const char *errmsg;
+  enum cgen_parse_operand_result result_type = CGEN_PARSE_OPERAND_RESULT_NUMBER;
+  bfd_vma value;
+
+  nios_parsed_i11 = 1;
+
+  if (strncasecmp (*strp, "%hi(", 4) == 0)
+    {
+      *strp += 4;
+      if (**strp == '-' || isdigit(**strp))
+	{
+	  errmsg = cgen_parse_signed_integer (cd, strp, opindex, &value);
+	  if (**strp != ')')
+	    return _("missing ')'");
+	  ++*strp;
+	}
+      else 
+        {
+	  char *k = strchr (*strp, '@');
+	  if (k != NULL && k[1] == 'h')
+	    {
+	      errmsg = parse_h_address (cd, strp, k, opindex, BFD_RELOC_NIOS_H_HI11,
+					   &result_type, &value);
+	      value >>= 1;
+	    }
+	  else
+	    {
+	      errmsg = cgen_parse_address (cd, strp, opindex, BFD_RELOC_NIOS_LO16_HI11,
+					   &result_type, &value);
+	    }
+	  if (**strp != ')')
+	    return _("missing ')'");
+	  ++*strp;
+	}
+      if (result_type == CGEN_PARSE_OPERAND_RESULT_NUMBER)
+	value = (value & 0xffff) >> 5;
+      *valuep = value;
+      return errmsg;
+    }
+  else if (strncasecmp (*strp, "%xhi(", 5) == 0)
+    {
+      *strp += 5;
+      if (**strp == '-' || isdigit(**strp))
+	{
+	  errmsg = cgen_parse_signed_integer (cd, strp, opindex, &value);
+	  if (**strp != ')')
+	    return _("missing ')'");
+	  ++*strp;
+	}
+      else 
+        {
+	  char *k = strchr (*strp, '@');
+	  if (k != NULL && k[1] == 'h')
+	    {
+	      errmsg = parse_h_address (cd, strp, k, opindex, BFD_RELOC_NIOS_H_XHI11,
+					   &result_type, &value);
+	      value >>= 1;
+	    }
+	  else
+	    {
+	      errmsg = cgen_parse_address (cd, strp, opindex, BFD_RELOC_NIOS_HI16_HI11,
+					   &result_type, &value);
+	    }
+	  if (**strp != ')')
+	    return _("missing ')'");
+	  ++*strp;
+	}
+
+      if (result_type == CGEN_PARSE_OPERAND_RESULT_NUMBER)
+	value = (value >> 21);
+      *valuep = value;
+      return errmsg;
+    }
+
+  errmsg = cgen_parse_signed_integer (cd, strp, opindex, &value);
+  if ((long)value > 0x7ff || (long)value < -0x800)
+    return _("immediate value out of range");
+  value &= 0x7ff;
+  *valuep = value;
+  return errmsg;
+}
+
+static const char *
+parse_save_i8v (cd, strp, opindex, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     int opindex;
+     unsigned long *valuep;
+{
+  const char *errmsg;
+  bfd_vma value;
+
+  errmsg = cgen_parse_signed_integer (cd, strp, opindex, &value);
+  if ((long)value > 0)
+    return _("stack alteration value must be negative or zero");
+  value = 0-(long)value;
+    
+  if (value > 0xff)
+    return _("immediate value out of range");
+  *valuep = value;
+  return errmsg;
+}
+
+/* parse possible condition code masks */
+static const char *
+parse_i4w (cd, strp, opindex, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     int opindex;
+     unsigned long *valuep;
+{
+  const char *errmsg;
+  bfd_vma value;
+  char ch, ch2;
+  int not_flag = 0;
+  int cc = 0;
+
+  value = 0xffff;
+
+  if (strncasecmp (*strp, "cc_", 3) == 0)
+    {
+      cc = 1;
+      *strp += 3;
+    }
+  else if (strncasecmp (*strp, "!cc_", 4) == 0)
+    {
+      cc = 1;
+      *strp += 4;
+      not_flag = 1;
+    }
+
+  if (cc)
+    {
+      errmsg = NULL;
+      ch = **strp;
+      ++*strp;
+      switch (ch)
+	{
+	case 'z':
+	  value = CC_Z;
+	  break;
+	
+	case 'g':
+	  ch2 = **strp;
+	  if (ch2 == 'e')
+	    {
+	      value = CC_GE;
+	      ++*strp;
+	    }
+	  else if (ch2 == 't')
+	    {
+	      value = CC_GT;
+	      ++*strp;
+	    }
+	  break;
+	
+	case 'l':
+	  ch2 = **strp;
+	  if (ch2 == 'e')
+	    {
+	      value = CC_LE;
+	      ++*strp;
+	    }
+	  else if (ch2 == 't')
+	    {
+	      value = CC_LT;
+	      ++*strp;
+	    }
+	  else if (ch2 == 's')
+	    {
+	      value = CC_LS;
+	      ++*strp;
+	    }
+	  break;
+	
+	case 'h':
+	  if (**strp == 'i')
+	    {
+	      value = CC_HI;
+	      ++*strp;
+	    }
+	  break;
+	
+	case 'p':
+	  ch2 = **strp;
+	  if (ch2 == 'l')
+	    {
+	      value = CC_PL;
+	      ++*strp;
+	    }
+	  else if (ch2 == '\0' || isspace (ch2))
+	    value = CC_PL;
+	  break;
+
+	case 'm':
+	  ch2 = **strp;
+	  if (ch2 == 'i')
+	    {
+	      value = CC_MI;
+	      ++*strp;
+	    }
+	  break;
+
+	case 'e':
+	  ch2 = **strp;
+	  if (ch2 == 'q')
+	    {
+	      value = CC_Z;
+	      ++*strp;
+	    }
+	  break;
+	
+	case 'n':
+	  ch2 = **strp;
+	  if (ch2 == 'z' || ch2 == 'e')
+	    {
+	      value = CC_NZ;
+	      ++*strp;
+	    }
+	  else if (ch2 == 'e')
+	    {
+	      value = CC_NZ;
+	      ++*strp;
+	    }
+	  else if (ch2 == 'c')
+	    {
+	      value = CC_NC;
+	      ++*strp;
+	    }
+	  else if (ch2 == 'v')
+	    {
+	      value = CC_NV;
+	      ++*strp;
+	    }
+	  else if (ch2 == '\0' || isspace(ch2))
+	    {
+	      value = CC_MI;
+	    }
+	  break;
+	
+	case 'v':
+	  ch2 = **strp;
+	  if (ch2 == 'c')
+	    {
+	      value = CC_NV;
+	      ++*strp;
+	    }
+	  else if (ch2 == 's')
+	    {
+	      value = CC_V;
+	      ++*strp;
+	    }
+	  else if (ch2 == '\0' || isspace(ch2))
+	    {
+	      value = CC_V;
+	    }
+	  break;
+	
+	case 'c':
+	  ch2 = **strp;
+	  if (ch2 == 'c')
+	    {
+	      value = CC_NC;
+	      ++*strp;
+	    }
+	  else if (ch2 == 's')
+	    {
+	      value = CC_C;
+	      ++*strp;
+	    }
+	  else if (ch2 == '\0' || isspace(ch2))
+	    {
+	      value = CC_C;
+	    }
+	  break;
+	}
+	
+	if (value == 0xffff || **strp != '\0' && !isspace (**strp))
+	  return _("invalid condition code mask specified");
+	if (not_flag)
+	  value ^= 1;
+    }
+  else
+    {
+      errmsg = cgen_parse_unsigned_integer (cd, strp, opindex, &value);
+      if (value > CC_MAX)
+	return _("invalid condition code mask specified");
+    }
+  *valuep = value;
+  return errmsg;
+}
+
+/* parse possible condition code masks for ifs */
+static const char *
+parse_i4wn (cd, strp, opindex, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     int opindex;
+     unsigned long *valuep;
+{
+  const char *errmsg;
+
+  errmsg = parse_i4w (cd, strp, opindex, valuep);
+  *valuep ^= 1;
+  return errmsg;
+}
+
+
+
+static const char *
+parse_i16 (cd, strp, opindex, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     int opindex;
+     unsigned long *valuep;
+{
+  const char *errmsg;
+  bfd_vma value;
+
+  errmsg = cgen_parse_unsigned_integer (cd, strp, opindex, &value);
+  if (value > 0xffff)
+    return _("immediate value out of range");
+  *valuep = value;
+  return errmsg;
+}
+
+static const char *
+parse_i32 (cd, strp, opindex, valuep)
+     CGEN_CPU_DESC cd;
+     const char **strp;
+     int opindex;
+     unsigned long *valuep;
+{
+  const char *errmsg;
+
+  errmsg = cgen_parse_unsigned_integer (cd, strp, opindex, valuep);
+  return errmsg;
+}
+
+
+/* -- dis.c */
+
+/* Main entry point for operand parsing.
+
+   This function is basically just a big switch statement.  Earlier versions
+   used tables to look up the function to use, but
+   - if the table contains both assembler and disassembler functions then
+     the disassembler contains much of the assembler and vice-versa,
+   - there's a lot of inlining possibilities as things grow,
+   - using a switch statement avoids the function call overhead.
+
+   This function could be moved into `parse_insn_normal', but keeping it
+   separate makes clear the interface between `parse_insn_normal' and each of
+   the handlers.
+*/
+
+const char *
+nios_cgen_parse_operand (cd, opindex, strp, fields)
+     CGEN_CPU_DESC cd;
+     int opindex;
+     const char ** strp;
+     CGEN_FIELDS * fields;
+{
+  const char * errmsg = NULL;
+  /* Used by scalar operands that still need to be parsed.  */
+  long junk;
+
+  switch (opindex)
+    {
+    case NIOS_OPERAND_CTLC :
+      errmsg = cgen_parse_unsigned_integer (cd, strp, NIOS_OPERAND_CTLC, &fields->f_CTLc);
+      break;
+    case NIOS_OPERAND_RBI5 :
+      errmsg = parse_Rbi5 (cd, strp, NIOS_OPERAND_RBI5, &fields->f_Rbi5);
+      break;
+    case NIOS_OPERAND_BSRR_REL6 :
+      {
+        bfd_vma value;
+        errmsg = cgen_parse_address (cd, strp, NIOS_OPERAND_BSRR_REL6, 0, NULL,  & value);
+        fields->f_bsrr_i6_rel = value;
+      }
+      break;
+    case NIOS_OPERAND_I1 :
+      errmsg = cgen_parse_unsigned_integer (cd, strp, NIOS_OPERAND_I1, &fields->f_i1);
+      break;
+    case NIOS_OPERAND_I10 :
+      errmsg = parse_i10 (cd, strp, NIOS_OPERAND_I10, &fields->f_i10);
+      break;
+    case NIOS_OPERAND_I11 :
+      errmsg = parse_i11 (cd, strp, NIOS_OPERAND_I11, &fields->f_i11);
+      break;
+    case NIOS_OPERAND_I2 :
+      errmsg = cgen_parse_unsigned_integer (cd, strp, NIOS_OPERAND_I2, &fields->f_i2);
+      break;
+    case NIOS_OPERAND_I4W :
+      errmsg = parse_i4w (cd, strp, NIOS_OPERAND_I4W, &fields->f_i4w);
+      break;
+    case NIOS_OPERAND_I4WN :
+      errmsg = parse_i4wn (cd, strp, NIOS_OPERAND_I4WN, &fields->f_i4w);
+      break;
+    case NIOS_OPERAND_I5 :
+      errmsg = parse_i5 (cd, strp, NIOS_OPERAND_I5, &fields->f_i5);
+      break;
+    case NIOS_OPERAND_I6V :
+      errmsg = cgen_parse_unsigned_integer (cd, strp, NIOS_OPERAND_I6V, &fields->f_i6v);
+      break;
+    case NIOS_OPERAND_I8 :
+      errmsg = cgen_parse_unsigned_integer (cd, strp, NIOS_OPERAND_I8, &fields->f_i8);
+      break;
+    case NIOS_OPERAND_I8V :
+      errmsg = cgen_parse_unsigned_integer (cd, strp, NIOS_OPERAND_I8V, &fields->f_i8v);
+      break;
+    case NIOS_OPERAND_I9 :
+      errmsg = parse_i9 (cd, strp, NIOS_OPERAND_I9, &fields->f_i9);
+      break;
+    case NIOS_OPERAND_M16_R0 :
+      errmsg = cgen_parse_keyword (cd, strp, & nios_cgen_opval_h_m16_gr0, & junk);
+      break;
+    case NIOS_OPERAND_M16_RA :
+      errmsg = cgen_parse_keyword (cd, strp, & nios_cgen_opval_gr_names, & fields->f_Ra);
+      break;
+    case NIOS_OPERAND_M16_RB :
+      errmsg = cgen_parse_keyword (cd, strp, & nios_cgen_opval_gr_names, & fields->f_Rb);
+      break;
+    case NIOS_OPERAND_M16_RP :
+      errmsg = cgen_parse_keyword (cd, strp, & nios_cgen_opval_bp_names, & fields->f_Rp);
+      break;
+    case NIOS_OPERAND_M16_RZ :
+      errmsg = cgen_parse_keyword (cd, strp, & nios_cgen_opval_gr_names, & fields->f_Rz);
+      break;
+    case NIOS_OPERAND_M16_I6 :
+      {
+        bfd_vma value;
+        errmsg = cgen_parse_address (cd, strp, NIOS_OPERAND_M16_I6, 0, NULL,  & value);
+        fields->f_i6_rel_h = value;
+      }
+      break;
+    case NIOS_OPERAND_M16_I8V :
+      {
+        bfd_vma value;
+        errmsg = cgen_parse_address (cd, strp, NIOS_OPERAND_M16_I8V, 0, NULL,  & value);
+        fields->f_i8v_rel_h = value;
+      }
+      break;
+    case NIOS_OPERAND_M16_SP :
+      errmsg = cgen_parse_keyword (cd, strp, & nios_cgen_opval_h_m16_sp, & junk);
+      break;
+    case NIOS_OPERAND_M32_R0 :
+      errmsg = cgen_parse_keyword (cd, strp, & nios_cgen_opval_gr0_name, & junk);
+      break;
+    case NIOS_OPERAND_M32_RA :
+      errmsg = cgen_parse_keyword (cd, strp, & nios_cgen_opval_gr_names, & fields->f_Ra);
+      break;
+    case NIOS_OPERAND_M32_RB :
+      errmsg = cgen_parse_keyword (cd, strp, & nios_cgen_opval_gr_names, & fields->f_Rb);
+      break;
+    case NIOS_OPERAND_M32_RP :
+      errmsg = cgen_parse_keyword (cd, strp, & nios_cgen_opval_bp_names, & fields->f_Rp);
+      break;
+    case NIOS_OPERAND_M32_RZ :
+      errmsg = cgen_parse_keyword (cd, strp, & nios_cgen_opval_gr_names, & fields->f_Rz);
+      break;
+    case NIOS_OPERAND_M32_I6 :
+      {
+        bfd_vma value;
+        errmsg = cgen_parse_address (cd, strp, NIOS_OPERAND_M32_I6, 0, NULL,  & value);
+        fields->f_i6_rel_w = value;
+      }
+      break;
+    case NIOS_OPERAND_M32_I8V :
+      {
+        bfd_vma value;
+        errmsg = cgen_parse_address (cd, strp, NIOS_OPERAND_M32_I8V, 0, NULL,  & value);
+        fields->f_i8v_rel_w = value;
+      }
+      break;
+    case NIOS_OPERAND_M32_SP :
+      errmsg = cgen_parse_keyword (cd, strp, & nios_cgen_opval_h_m32_sp, & junk);
+      break;
+    case NIOS_OPERAND_O1 :
+      errmsg = cgen_parse_unsigned_integer (cd, strp, NIOS_OPERAND_O1, &fields->f_o1);
+      break;
+    case NIOS_OPERAND_O2 :
+      errmsg = cgen_parse_unsigned_integer (cd, strp, NIOS_OPERAND_O2, &fields->f_o2);
+      break;
+    case NIOS_OPERAND_REL11 :
+      {
+        bfd_vma value;
+        errmsg = cgen_parse_address (cd, strp, NIOS_OPERAND_REL11, 0, NULL,  & value);
+        fields->f_i11_rel = value;
+      }
+      break;
+    case NIOS_OPERAND_SAVE_I8V :
+      errmsg = parse_save_i8v (cd, strp, NIOS_OPERAND_SAVE_I8V, &fields->f_i8v);
+      break;
+    case NIOS_OPERAND_SI11 :
+      errmsg = cgen_parse_signed_integer (cd, strp, NIOS_OPERAND_SI11, &fields->f_i11);
+      break;
+    case NIOS_OPERAND_SI5 :
+      errmsg = cgen_parse_signed_integer (cd, strp, NIOS_OPERAND_SI5, &fields->f_i5);
+      break;
+    case NIOS_OPERAND_X1 :
+      errmsg = cgen_parse_unsigned_integer (cd, strp, NIOS_OPERAND_X1, &fields->f_x1);
+      break;
+    case NIOS_OPERAND_XRA :
+      errmsg = cgen_parse_unsigned_integer (cd, strp, NIOS_OPERAND_XRA, &fields->f_Ra);
+      break;
+
+    default :
+      /* xgettext:c-format */
+      fprintf (stderr, _("Unrecognized field %d while parsing.\n"), opindex);
+      abort ();
+  }
+
+  return errmsg;
+}
+
+cgen_parse_fn * const nios_cgen_parse_handlers[] = 
+{
+  parse_insn_normal,
+};
+
+void
+nios_cgen_init_asm (cd)
+     CGEN_CPU_DESC cd;
+{
+  nios_cgen_init_opcode_table (cd);
+  nios_cgen_init_ibld_table (cd);
+  cd->parse_handlers = & nios_cgen_parse_handlers[0];
+  cd->parse_operand = nios_cgen_parse_operand;
+}
+
+
+/* Default insn parser.
+
+   The syntax string is scanned and operands are parsed and stored in FIELDS.
+   Relocs are queued as we go via other callbacks.
+
+   ??? Note that this is currently an all-or-nothing parser.  If we fail to
+   parse the instruction, we return 0 and the caller will start over from
+   the beginning.  Backtracking will be necessary in parsing subexpressions,
+   but that can be handled there.  Not handling backtracking here may get
+   expensive in the case of the m68k.  Deal with later.
+
+   Returns NULL for success, an error message for failure.
+*/
+
+static const char *
+parse_insn_normal (cd, insn, strp, fields)
+     CGEN_CPU_DESC cd;
+     const CGEN_INSN *insn;
+     const char **strp;
+     CGEN_FIELDS *fields;
+{
+  /* ??? Runtime added insns not handled yet.  */
+  const CGEN_SYNTAX *syntax = CGEN_INSN_SYNTAX (insn);
+  const char *str = *strp;
+  const char *errmsg;
+  const char *p;
+  const unsigned char * syn;
+#ifdef CGEN_MNEMONIC_OPERANDS
+  /* FIXME: wip */
+  int past_opcode_p;
+#endif
+
+  /* For now we assume the mnemonic is first (there are no leading operands).
+     We can parse it without needing to set up operand parsing.
+     GAS's input scrubber will ensure mnemonics are lowercase, but we may
+     not be called from GAS.  */
+  p = CGEN_INSN_MNEMONIC (insn);
+  while (*p && tolower (*p) == tolower (*str))
+    ++p, ++str;
+
+  if (* p)
+    return _("unrecognized instruction");
+
+#ifndef CGEN_MNEMONIC_OPERANDS
+  if (* str && !isspace (* str))
+    return _("unrecognized instruction");
+#endif
+
+  CGEN_INIT_PARSE (cd);
+  cgen_init_parse_operand (cd);
+#ifdef CGEN_MNEMONIC_OPERANDS
+  past_opcode_p = 0;
+#endif
+
+  /* We don't check for (*str != '\0') here because we want to parse
+     any trailing fake arguments in the syntax string.  */
+  syn = CGEN_SYNTAX_STRING (syntax);
+
+  /* Mnemonics come first for now, ensure valid string.  */
+  if (! CGEN_SYNTAX_MNEMONIC_P (* syn))
+    abort ();
+
+  ++syn;
+
+  while (* syn != 0)
+    {
+      /* Non operand chars must match exactly.  */
+      if (CGEN_SYNTAX_CHAR_P (* syn))
+	{
+	  /* FIXME: While we allow for non-GAS callers above, we assume the
+	     first char after the mnemonic part is a space.  */
+	  /* FIXME: We also take inappropriate advantage of the fact that
+	     GAS's input scrubber will remove extraneous blanks.  */
+	  if (tolower (*str) == tolower (CGEN_SYNTAX_CHAR (* syn)))
+	    {
+#ifdef CGEN_MNEMONIC_OPERANDS
+	      if (* syn == ' ')
+		past_opcode_p = 1;
+#endif
+	      ++ syn;
+	      ++ str;
+	    }
+	  else
+	    {
+	      /* Syntax char didn't match.  Can't be this insn.  */
+	      static char msg [80];
+	      /* xgettext:c-format */
+	      sprintf (msg, _("syntax error (expected char `%c', found `%c')"),
+		       *syn, *str);
+	      return msg;
+	    }
+	  continue;
+	}
+
+      /* We have an operand of some sort.  */
+      errmsg = nios_cgen_parse_operand (cd, CGEN_SYNTAX_FIELD (*syn),
+					  &str, fields);
+      if (errmsg)
+	return errmsg;
+
+      /* Done with this operand, continue with next one.  */
+      ++ syn;
+    }
+
+  /* If we're at the end of the syntax string, we're done.  */
+  if (* syn == '\0')
+    {
+      /* FIXME: For the moment we assume a valid `str' can only contain
+	 blanks now.  IE: We needn't try again with a longer version of
+	 the insn and it is assumed that longer versions of insns appear
+	 before shorter ones (eg: lsr r2,r3,1 vs lsr r2,r3).  */
+      while (isspace (* str))
+	++ str;
+
+      if (* str != '\0')
+	return _("junk at end of line"); /* FIXME: would like to include `str' */
+
+      return NULL;
+    }
+
+  /* We couldn't parse it.  */
+  return _("unrecognized instruction");
+}
+
+/* Main entry point.
+   This routine is called for each instruction to be assembled.
+   STR points to the insn to be assembled.
+   We assume all necessary tables have been initialized.
+   The assembled instruction, less any fixups, is stored in BUF.
+   Remember that if CGEN_INT_INSN_P then BUF is an int and thus the value
+   still needs to be converted to target byte order, otherwise BUF is an array
+   of bytes in target byte order.
+   The result is a pointer to the insn's entry in the opcode table,
+   or NULL if an error occured (an error message will have already been
+   printed).
+
+   Note that when processing (non-alias) macro-insns,
+   this function recurses.
+
+   ??? It's possible to make this cpu-independent.
+   One would have to deal with a few minor things.
+   At this point in time doing so would be more of a curiosity than useful
+   [for example this file isn't _that_ big], but keeping the possibility in
+   mind helps keep the design clean.  */
+
+const CGEN_INSN *
+nios_cgen_assemble_insn (cd, str, fields, buf, errmsg)
+     CGEN_CPU_DESC cd;
+     const char *str;
+     CGEN_FIELDS *fields;
+     CGEN_INSN_BYTES_PTR buf;
+     char **errmsg;
+{
+  const char *start;
+  CGEN_INSN_LIST *ilist;
+  const char *tmp_errmsg;
+
+  /* Skip leading white space.  */
+  while (isspace (* str))
+    ++ str;
+
+  /* The instructions are stored in hashed lists.
+     Get the first in the list.  */
+  ilist = CGEN_ASM_LOOKUP_INSN (cd, str);
+
+  /* Keep looking until we find a match.  */
+
+  start = str;
+  for ( ; ilist != NULL ; ilist = CGEN_ASM_NEXT_INSN (ilist))
+    {
+      const CGEN_INSN *insn = ilist->insn;
+
+#ifdef CGEN_VALIDATE_INSN_SUPPORTED 
+      /* not usually needed as unsupported opcodes shouldn't be in the hash lists */
+      /* Is this insn supported by the selected cpu?  */
+      if (! nios_cgen_insn_supported (cd, insn))
+	continue;
+#endif
+
+      /* If the RELAX attribute is set, this is an insn that shouldn't be
+	 chosen immediately.  Instead, it is used during assembler/linker
+	 relaxation if possible.  */
+      if (CGEN_INSN_ATTR_VALUE (insn, CGEN_INSN_RELAX) != 0)
+	continue;
+
+      str = start;
+
+      /* Allow parse/insert handlers to obtain length of insn.  */
+      CGEN_FIELDS_BITSIZE (fields) = CGEN_INSN_BITSIZE (insn);
+
+      if (!(tmp_errmsg = CGEN_PARSE_FN (cd, insn) (cd, insn, & str, fields)))
+	{
+	  /* ??? 0 is passed for `pc' */
+	  if (CGEN_INSERT_FN (cd, insn) (cd, insn, fields, buf, (bfd_vma) 0)
+	      != NULL)
+	    continue;
+	  /* It is up to the caller to actually output the insn and any
+	     queued relocs.  */
+	  return insn;
+	}
+
+      /* Try the next entry.  */
+    }
+
+  {
+    static char errbuf[150];
+
+#ifdef CGEN_VERBOSE_ASSEMBLER_ERRORS
+    /* if verbose error messages, use errmsg from CGEN_PARSE_FN */
+    if (strlen (start) > 50)
+      /* xgettext:c-format */
+      sprintf (errbuf, "%s `%.50s...'", tmp_errmsg, start);
+    else 
+      /* xgettext:c-format */
+      sprintf (errbuf, "%s `%.50s'", tmp_errmsg, start);
+#else
+    if (strlen (start) > 50)
+      /* xgettext:c-format */
+      sprintf (errbuf, _("bad instruction `%.50s...'"), start);
+    else 
+      /* xgettext:c-format */
+      sprintf (errbuf, _("bad instruction `%.50s'"), start);
+#endif
+      
+    *errmsg = errbuf;
+    return NULL;
+  }
+}
+
+#if 0 /* This calls back to GAS which we can't do without care.  */
+
+/* Record each member of OPVALS in the assembler's symbol table.
+   This lets GAS parse registers for us.
+   ??? Interesting idea but not currently used.  */
+
+/* Record each member of OPVALS in the assembler's symbol table.
+   FIXME: Not currently used.  */
+
+void
+nios_cgen_asm_hash_keywords (cd, opvals)
+     CGEN_CPU_DESC cd;
+     CGEN_KEYWORD *opvals;
+{
+  CGEN_KEYWORD_SEARCH search = cgen_keyword_search_init (opvals, NULL);
+  const CGEN_KEYWORD_ENTRY * ke;
+
+  while ((ke = cgen_keyword_search_next (& search)) != NULL)
+    {
+#if 0 /* Unnecessary, should be done in the search routine.  */
+      if (! nios_cgen_opval_supported (ke))
+	continue;
+#endif
+      cgen_asm_record_register (cd, ke->name, ke->value);
+    }
+}
+
+#endif /* 0 */

--- a/libr/asm/arch/nios/gnu/nios-asm.c
+++ b/libr/asm/arch/nios/gnu/nios-asm.c
@@ -29,7 +29,8 @@ along with this program; if not, write to the Free Software Foundation, Inc.,
 #include <ctype.h>
 #include <stdio.h>
 #include "ansidecl.h"
-#include "bfd.h"
+//#include "bfd.h"
+#include "mybfd.h"
 #include "symcat.h"
 #include "nios-desc.h"
 #include "nios-opc.h"

--- a/libr/asm/arch/nios/gnu/nios-desc.c
+++ b/libr/asm/arch/nios/gnu/nios-desc.c
@@ -27,7 +27,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <stdio.h>
 #include <stdarg.h>
 #include "ansidecl.h"
-#include "bfd.h"
+//#include "bfd.h"
+#include "mybfd.h"
 #include "symcat.h"
 #include "nios-desc.h"
 #include "nios-opc.h"

--- a/libr/asm/arch/nios/gnu/nios-desc.c
+++ b/libr/asm/arch/nios/gnu/nios-desc.c
@@ -2,30 +2,32 @@
 
 THIS FILE IS MACHINE GENERATED WITH CGEN.
 
-Copyright (C) 1996, 1997, 1998, 1999, 2001 Free Software Foundation, Inc.
+Copyright (C) 1996-2018 Free Software Foundation, Inc.
 
 This file is part of the GNU Binutils and/or GDB, the GNU debugger.
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2, or (at your option)
-any later version.
+   This file is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3, or (at your option)
+   any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+   It is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+   License for more details.
 
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.
 
 */
 
 #include "sysdep.h"
 #include <ctype.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <stdarg.h>
+#include <string.h>
 #include "ansidecl.h"
 //#include "bfd.h"
 #include "mybfd.h"
@@ -33,6 +35,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "nios-desc.h"
 #include "nios-opc.h"
 #include "opintl.h"
+#include "libiberty.h"
+#include "xregex.h"
 
 /* Attributes.  */
 
@@ -43,7 +47,7 @@ static const CGEN_ATTR_ENTRY bool_attr[] =
   { 0, 0 }
 };
 
-static const CGEN_ATTR_ENTRY MACH_attr[] =
+static const CGEN_ATTR_ENTRY MACH_attr[] ATTRIBUTE_UNUSED =
 {
   { "base", MACH_BASE },
   { "nios16", MACH_NIOS16 },
@@ -52,7 +56,7 @@ static const CGEN_ATTR_ENTRY MACH_attr[] =
   { 0, 0 }
 };
 
-static const CGEN_ATTR_ENTRY ISA_attr[] =
+static const CGEN_ATTR_ENTRY ISA_attr[] ATTRIBUTE_UNUSED =
 {
   { "nios", ISA_NIOS },
   { "max", ISA_MAX },
@@ -61,19 +65,20 @@ static const CGEN_ATTR_ENTRY ISA_attr[] =
 
 const CGEN_ATTR_TABLE nios_cgen_ifield_attr_table[] =
 {
-  { "MACH", & MACH_attr[0] },
+  { "MACH", & MACH_attr[0], & MACH_attr[0] },
   { "VIRTUAL", &bool_attr[0], &bool_attr[0] },
   { "PCREL-ADDR", &bool_attr[0], &bool_attr[0] },
   { "ABS-ADDR", &bool_attr[0], &bool_attr[0] },
   { "RESERVED", &bool_attr[0], &bool_attr[0] },
   { "SIGN-OPT", &bool_attr[0], &bool_attr[0] },
   { "SIGNED", &bool_attr[0], &bool_attr[0] },
+  { "RELOC", &bool_attr[0], &bool_attr[0] },
   { 0, 0, 0 }
 };
 
 const CGEN_ATTR_TABLE nios_cgen_hardware_attr_table[] =
 {
-  { "MACH", & MACH_attr[0] },
+  { "MACH", & MACH_attr[0], & MACH_attr[0] },
   { "VIRTUAL", &bool_attr[0], &bool_attr[0] },
   { "CACHE-ADDR", &bool_attr[0], &bool_attr[0] },
   { "PC", &bool_attr[0], &bool_attr[0] },
@@ -83,7 +88,7 @@ const CGEN_ATTR_TABLE nios_cgen_hardware_attr_table[] =
 
 const CGEN_ATTR_TABLE nios_cgen_operand_attr_table[] =
 {
-  { "MACH", & MACH_attr[0] },
+  { "MACH", & MACH_attr[0], & MACH_attr[0] },
   { "VIRTUAL", &bool_attr[0], &bool_attr[0] },
   { "PCREL-ADDR", &bool_attr[0], &bool_attr[0] },
   { "ABS-ADDR", &bool_attr[0], &bool_attr[0] },
@@ -98,7 +103,7 @@ const CGEN_ATTR_TABLE nios_cgen_operand_attr_table[] =
 
 const CGEN_ATTR_TABLE nios_cgen_insn_attr_table[] =
 {
-  { "MACH", & MACH_attr[0] },
+  { "MACH", & MACH_attr[0], & MACH_attr[0] },
   { "ALIAS", &bool_attr[0], &bool_attr[0] },
   { "VIRTUAL", &bool_attr[0], &bool_attr[0] },
   { "UNCOND-CTI", &bool_attr[0], &bool_attr[0] },
@@ -106,7 +111,7 @@ const CGEN_ATTR_TABLE nios_cgen_insn_attr_table[] =
   { "SKIP-CTI", &bool_attr[0], &bool_attr[0] },
   { "DELAY-SLOT", &bool_attr[0], &bool_attr[0] },
   { "RELAXABLE", &bool_attr[0], &bool_attr[0] },
-  { "RELAX", &bool_attr[0], &bool_attr[0] },
+  { "RELAXED", &bool_attr[0], &bool_attr[0] },
   { "NO-DIS", &bool_attr[0], &bool_attr[0] },
   { "PBB", &bool_attr[0], &bool_attr[0] },
   { "PREFIX", &bool_attr[0], &bool_attr[0] },
@@ -120,158 +125,163 @@ const CGEN_ATTR_TABLE nios_cgen_insn_attr_table[] =
 
 static const CGEN_ISA nios_cgen_isa_table[] = {
   { "nios", 16, 16, 16, 16,  },
-  { 0 }
+  { 0, 0, 0, 0, 0 }
 };
 
 /* Machine variants.  */
 
 static const CGEN_MACH nios_cgen_mach_table[] = {
-  { "nios16", "nios16", MACH_NIOS16 },
-  { "nios32", "nios32", MACH_NIOS32 },
-  { 0 }
+  { "nios16", "nios16", MACH_NIOS16, 0 },
+  { "nios32", "nios32", MACH_NIOS32, 0 },
+  { 0, 0, 0, 0 }
 };
 
 static CGEN_KEYWORD_ENTRY nios_cgen_opval_ctl_names_entries[] =
 {
-  { "%ctl0", 0 },
-  { "%ctl1", 1 },
-  { "%ctl2", 2 },
-  { "%ctl3", 3 },
-  { "%ctl4", 4 },
-  { "%ctl5", 5 },
-  { "%status", 0 },
-  { "%istatus", 1 },
-  { "%wvalid", 2 },
-  { "%cd_bank", 3 },
-  { "%st_bank", 4 },
-  { "%ld_bank", 5 }
+  { "ctl0", 0 },
+  { "ctl1", 1 },
+  { "ctl2", 2 },
+  { "ctl3", 3 },
+  { "ctl4", 4 },
+  { "ctl5", 5 },
+  { "status", 0 },
+  { "istatus", 1 },
+  { "wvalid", 2 },
+  { "cd_bank", 3 },
+  { "st_bank", 4 },
+  { "ld_bank", 5 }
 };
 
 CGEN_KEYWORD nios_cgen_opval_ctl_names =
 {
   & nios_cgen_opval_ctl_names_entries[0],
-  12
+  12,
+  0, 0, 0, 0, ""
 };
 
 static CGEN_KEYWORD_ENTRY nios_cgen_opval_gr_names_entries[] =
 {
-  { "%sp", 14 },
-  { "%fp", 30 },
-  { "%g0", 0 },
-  { "%g1", 1 },
-  { "%g2", 2 },
-  { "%g3", 3 },
-  { "%g4", 4 },
-  { "%g5", 5 },
-  { "%g6", 6 },
-  { "%g7", 7 },
-  { "%r0", 0 },
-  { "%r1", 1 },
-  { "%r2", 2 },
-  { "%r3", 3 },
-  { "%r4", 4 },
-  { "%r5", 5 },
-  { "%r6", 6 },
-  { "%r7", 7 },
-  { "%o0", 8 },
-  { "%o1", 9 },
-  { "%o2", 10 },
-  { "%o3", 11 },
-  { "%o4", 12 },
-  { "%o5", 13 },
-  { "%o6", 14 },
-  { "%o7", 15 },
-  { "%r8", 8 },
-  { "%r9", 9 },
-  { "%r10", 10 },
-  { "%r11", 11 },
-  { "%r12", 12 },
-  { "%r13", 13 },
-  { "%r14", 14 },
-  { "%r15", 15 },
-  { "%l0", 16 },
-  { "%l1", 17 },
-  { "%l2", 18 },
-  { "%l3", 19 },
-  { "%l4", 20 },
-  { "%l5", 21 },
-  { "%l6", 22 },
-  { "%l7", 23 },
-  { "%r16", 16 },
-  { "%r17", 17 },
-  { "%r18", 18 },
-  { "%r19", 19 },
-  { "%r20", 20 },
-  { "%r21", 21 },
-  { "%r22", 22 },
-  { "%r23", 23 },
-  { "%i0", 24 },
-  { "%i1", 25 },
-  { "%i2", 26 },
-  { "%i3", 27 },
-  { "%i4", 28 },
-  { "%i5", 29 },
-  { "%i6", 30 },
-  { "%i7", 31 },
-  { "%r24", 24 },
-  { "%r25", 25 },
-  { "%r26", 26 },
-  { "%r27", 27 },
-  { "%r28", 28 },
-  { "%r29", 29 },
-  { "%r30", 30 },
-  { "%r31", 31 }
+  { "sp", 14 },
+  { "fp", 30 },
+  { "g0", 0 },
+  { "g1", 1 },
+  { "g2", 2 },
+  { "g3", 3 },
+  { "g4", 4 },
+  { "g5", 5 },
+  { "g6", 6 },
+  { "g7", 7 },
+  { "r0", 0 },
+  { "r1", 1 },
+  { "r2", 2 },
+  { "r3", 3 },
+  { "r4", 4 },
+  { "r5", 5 },
+  { "r6", 6 },
+  { "r7", 7 },
+  { "o0", 8 },
+  { "o1", 9 },
+  { "o2", 10 },
+  { "o3", 11 },
+  { "o4", 12 },
+  { "o5", 13 },
+  { "o6", 14 },
+  { "o7", 15 },
+  { "r8", 8 },
+  { "r9", 9 },
+  { "r10", 10 },
+  { "r11", 11 },
+  { "r12", 12 },
+  { "r13", 13 },
+  { "r14", 14 },
+  { "r15", 15 },
+  { "l0", 16 },
+  { "l1", 17 },
+  { "l2", 18 },
+  { "l3", 19 },
+  { "l4", 20 },
+  { "l5", 21 },
+  { "l6", 22 },
+  { "l7", 23 },
+  { "r16", 16 },
+  { "r17", 17 },
+  { "r18", 18 },
+  { "r19", 19 },
+  { "r20", 20 },
+  { "r21", 21 },
+  { "r22", 22 },
+  { "r23", 23 },
+  { "i0", 24 },
+  { "i1", 25 },
+  { "i2", 26 },
+  { "i3", 27 },
+  { "i4", 28 },
+  { "i5", 29 },
+  { "i6", 30 },
+  { "i7", 31 },
+  { "r24", 24 },
+  { "r25", 25 },
+  { "r26", 26 },
+  { "r27", 27 },
+  { "r28", 28 },
+  { "r29", 29 },
+  { "r30", 30 },
+  { "r31", 31 }
 };
 
 CGEN_KEYWORD nios_cgen_opval_gr_names =
 {
   & nios_cgen_opval_gr_names_entries[0],
-  66
+  66,
+  0, 0, 0, 0, ""
 };
 
 static CGEN_KEYWORD_ENTRY nios_cgen_opval_gr0_name_entries[] =
 {
-  { "%r0", 0 }
+  { "r0", 0 }
 };
 
 CGEN_KEYWORD nios_cgen_opval_gr0_name =
 {
   & nios_cgen_opval_gr0_name_entries[0],
-  1
+  1,
+  0, 0, 0, 0, ""
 };
 
 static CGEN_KEYWORD_ENTRY nios_cgen_opval_bp_names_entries[] =
 {
-  { "%l0", 0 },
-  { "%l1", 1 },
-  { "%l2", 2 },
-  { "%l3", 3 },
-  { "%r16", 0 },
-  { "%r17", 1 },
-  { "%r18", 2 },
-  { "%r19", 3 }
+  { "l0", 0 },
+  { "l1", 1 },
+  { "l2", 2 },
+  { "l3", 3 },
+  { "r16", 0 },
+  { "r17", 1 },
+  { "r18", 2 },
+  { "r19", 3 }
 };
 
 CGEN_KEYWORD nios_cgen_opval_bp_names =
 {
   & nios_cgen_opval_bp_names_entries[0],
-  8
+  8,
+  0, 0, 0, 0, ""
 };
 
 static CGEN_KEYWORD_ENTRY nios_cgen_opval_h_m16_gr0_entries[] =
 {
-  { "%r0", 0 }
+  { "r0", 0 }
 };
 
 CGEN_KEYWORD nios_cgen_opval_h_m16_gr0 =
 {
   & nios_cgen_opval_h_m16_gr0_entries[0],
-  1
+  1,
+  0, 0, 0, 0, ""
 };
 
 static CGEN_KEYWORD_ENTRY nios_cgen_opval_h_m16_sp_entries[] =
 {
-  { "%sp", 0 }
+  { "sp", 0 }
 };
 
 CGEN_KEYWORD nios_cgen_opval_h_m16_sp =
@@ -282,7 +292,7 @@ CGEN_KEYWORD nios_cgen_opval_h_m16_sp =
 
 static CGEN_KEYWORD_ENTRY nios_cgen_opval_h_m32_sp_entries[] =
 {
-  { "%sp", 0 }
+  { "sp", 0 }
 };
 
 CGEN_KEYWORD nios_cgen_opval_h_m32_sp =
@@ -295,42 +305,42 @@ CGEN_KEYWORD nios_cgen_opval_h_m32_sp =
 
 /* The hardware table.  */
 
-#define A(a) (1 << CONCAT2 (CGEN_HW_,a))
+#define A(a) (1 << CGEN_HW_##a)
 
 const CGEN_HW_ENTRY nios_cgen_hw_table[] =
 {
-  { "h-memory", HW_H_MEMORY, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
-  { "h-sint", HW_H_SINT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
-  { "h-uint", HW_H_UINT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
-  { "h-addr", HW_H_ADDR, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
-  { "h-iaddr", HW_H_IADDR, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
-  { "h-pc", HW_H_PC, CGEN_ASM_NONE, 0, { 0|A(PROFILE)|A(PC), { (1<<MACH_BASE) } } },
-  { "h-cwp", HW_H_CWP, CGEN_ASM_NONE, 0, { 0|A(PROFILE), { (1<<MACH_BASE) } } },
-  { "h-old-cwp", HW_H_OLD_CWP, CGEN_ASM_NONE, 0, { 0|A(PROFILE), { (1<<MACH_BASE) } } },
-  { "h-ipri", HW_H_IPRI, CGEN_ASM_NONE, 0, { 0|A(CACHE_ADDR)|A(PROFILE), { (1<<MACH_BASE) } } },
-  { "h-zero", HW_H_ZERO, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
-  { "h-tebit", HW_H_TEBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
-  { "h-nbit", HW_H_NBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
-  { "h-zbit", HW_H_ZBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
-  { "h-vbit", HW_H_VBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
-  { "h-cbit", HW_H_CBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
-  { "h-pbit", HW_H_PBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
-  { "h-sbit", HW_H_SBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
-  { "h-wbit", HW_H_WBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
-  { "h-status", HW_H_STATUS, CGEN_ASM_NONE, 0, { 0|A(PROFILE), { (1<<MACH_BASE) } } },
-  { "h-k", HW_H_K, CGEN_ASM_NONE, 0, { 0|A(CACHE_ADDR)|A(PROFILE), { (1<<MACH_BASE) } } },
-  { "h-m16-gr", HW_H_M16_GR, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS16) } } },
-  { "h-m16-gr0", HW_H_M16_GR0, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_h_m16_gr0, { 0|A(VIRTUAL), { (1<<MACH_NIOS16) } } },
-  { "h-m16-bp", HW_H_M16_BP, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_bp_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS16) } } },
-  { "h-m16-rz", HW_H_M16_RZ, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS16) } } },
-  { "h-m16-sp", HW_H_M16_SP, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_h_m16_sp, { 0|A(VIRTUAL), { (1<<MACH_NIOS16) } } },
-  { "h-m16-ctl", HW_H_M16_CTL, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_ctl_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS16) } } },
-  { "h-m32-gr", HW_H_M32_GR, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS32) } } },
-  { "h-m32-gr0", HW_H_M32_GR0, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr0_name, { 0|A(VIRTUAL), { (1<<MACH_NIOS32) } } },
-  { "h-m32-bp", HW_H_M32_BP, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_bp_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS32) } } },
-  { "h-m32-rz", HW_H_M32_RZ, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS32) } } },
-  { "h-m32-sp", HW_H_M32_SP, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_h_m32_sp, { 0|A(VIRTUAL), { (1<<MACH_NIOS32) } } },
-  { "h-m32-ctl", HW_H_M32_CTL, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_ctl_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS32) } } },
+  { "h-memory", HW_H_MEMORY, CGEN_ASM_NONE, 0, { 0, { { { (1<<MACH_BASE) } } } } },
+  { "h-sint", HW_H_SINT, CGEN_ASM_NONE, 0, { 0, { { { (1<<MACH_BASE) } } } } },
+  { "h-uint", HW_H_UINT, CGEN_ASM_NONE, 0, { 0, { { { (1<<MACH_BASE) } } } } },
+  { "h-addr", HW_H_ADDR, CGEN_ASM_NONE, 0, { 0, { { { (1<<MACH_BASE) } } } } },
+  { "h-iaddr", HW_H_IADDR, CGEN_ASM_NONE, 0, { 0, { { { (1<<MACH_BASE) } } } } },
+  { "h-pc", HW_H_PC, CGEN_ASM_NONE, 0, { 0|A(PROFILE)|A(PC), { { { (1<<MACH_BASE) } } } } },
+  { "h-cwp", HW_H_CWP, CGEN_ASM_NONE, 0, { 0|A(PROFILE), { { { (1<<MACH_BASE) } } } } },
+  { "h-old-cwp", HW_H_OLD_CWP, CGEN_ASM_NONE, 0, { 0|A(PROFILE), { { { (1<<MACH_BASE) } } } } },
+  { "h-ipri", HW_H_IPRI, CGEN_ASM_NONE, 0, { 0|A(CACHE_ADDR)|A(PROFILE), { { { (1<<MACH_BASE) } } } } },
+  { "h-zero", HW_H_ZERO, CGEN_ASM_NONE, 0, { 0, { { { (1<<MACH_BASE) } } } } },
+  { "h-tebit", HW_H_TEBIT, CGEN_ASM_NONE, 0, { 0, { { { (1<<MACH_BASE) } } } } },
+  { "h-nbit", HW_H_NBIT, CGEN_ASM_NONE, 0, { 0, { { { (1<<MACH_BASE) } } } } },
+  { "h-zbit", HW_H_ZBIT, CGEN_ASM_NONE, 0, { 0, { { { (1<<MACH_BASE) } } } } },
+  { "h-vbit", HW_H_VBIT, CGEN_ASM_NONE, 0, { 0, { { { (1<<MACH_BASE) } } } } },
+  { "h-cbit", HW_H_CBIT, CGEN_ASM_NONE, 0, { 0, { { { (1<<MACH_BASE) } } } } },
+  { "h-pbit", HW_H_PBIT, CGEN_ASM_NONE, 0, { 0, { { { (1<<MACH_BASE) } } } } },
+  { "h-sbit", HW_H_SBIT, CGEN_ASM_NONE, 0, { 0, { { { (1<<MACH_BASE) } } } } },
+  { "h-wbit", HW_H_WBIT, CGEN_ASM_NONE, 0, { 0, { { { (1<<MACH_BASE) } } } } },
+  { "h-status", HW_H_STATUS, CGEN_ASM_NONE, 0, { 0|A(PROFILE), { { { (1<<MACH_BASE) } } } } },
+  { "h-k", HW_H_K, CGEN_ASM_NONE, 0, { 0|A(CACHE_ADDR)|A(PROFILE), { { { (1<<MACH_BASE) } } } } },
+  { "h-m16-gr", HW_H_M16_GR, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr_names, { 0|A(VIRTUAL), { { { (1<<MACH_NIOS16) } } } } },
+  { "h-m16-gr0", HW_H_M16_GR0, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_h_m16_gr0, { 0|A(VIRTUAL), { { { (1<<MACH_NIOS16) } } } } },
+  { "h-m16-bp", HW_H_M16_BP, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_bp_names, { 0|A(VIRTUAL), { { { (1<<MACH_NIOS16) } } } } },
+  { "h-m16-rz", HW_H_M16_RZ, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr_names, { 0|A(VIRTUAL), { { { (1<<MACH_NIOS16) } } } } },
+  { "h-m16-sp", HW_H_M16_SP, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_h_m16_sp, { 0|A(VIRTUAL), { { { (1<<MACH_NIOS16) } } } } },
+  { "h-m16-ctl", HW_H_M16_CTL, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_ctl_names, { 0|A(VIRTUAL), { { { (1<<MACH_NIOS16) } } } } },
+  { "h-m32-gr", HW_H_M32_GR, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr_names, { 0|A(VIRTUAL), { { { (1<<MACH_NIOS32) } } } } },
+  { "h-m32-gr0", HW_H_M32_GR0, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr0_name, { 0|A(VIRTUAL), { { { (1<<MACH_NIOS32) } } } } },
+  { "h-m32-bp", HW_H_M32_BP, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_bp_names, { 0|A(VIRTUAL), { { { (1<<MACH_NIOS32) } } } } },
+  { "h-m32-rz", HW_H_M32_RZ, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr_names, { 0|A(VIRTUAL), { { { (1<<MACH_NIOS32) } } } } },
+  { "h-m32-sp", HW_H_M32_SP, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_h_m32_sp, { 0|A(VIRTUAL), { { { (1<<MACH_NIOS32) } } } } },
+  { "h-m32-ctl", HW_H_M32_CTL, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_ctl_names, { 0|A(VIRTUAL), { { { (1<<MACH_NIOS32) } } } } },
   { 0 }
 };
 
@@ -338,45 +348,45 @@ const CGEN_HW_ENTRY nios_cgen_hw_table[] =
 
 /* The instruction field table.  */
 
-#define A(a) (1 << CONCAT2 (CGEN_IFLD_,a))
+#define A(a) (1 << CGEN_IFLD_##a)
 
 const CGEN_IFLD nios_cgen_ifld_table[] =
 {
-  { NIOS_F_NIL, "f-nil", 0, 0, 0, 0, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_ANYOF, "f-anyof", 0, 0, 0, 0, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_OP6, "f-op6", 0, 16, 15, 6, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_OP3, "f-op3", 0, 16, 15, 3, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_OP4, "f-op4", 0, 16, 15, 4, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_OP5, "f-op5", 0, 16, 15, 5, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_OP5_HI, "f-op5-hi", 16, 16, 15, 5, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_OP8, "f-op8", 0, 16, 15, 8, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_OP9, "f-op9", 0, 16, 15, 9, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_OP11, "f-op11", 0, 16, 15, 11, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_RA, "f-Ra", 0, 16, 4, 5, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_RB, "f-Rb", 0, 16, 9, 5, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_RBI5, "f-Rbi5", 0, 16, 9, 5, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_RZ, "f-Rz", 0, 16, 1, 2, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_RP, "f-Rp", 0, 16, 11, 2, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_CTLC, "f-CTLc", 0, 16, 4, 3, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_I2, "f-i2", 0, 16, 6, 2, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_I4W, "f-i4w", 0, 16, 3, 4, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_X1, "f-x1", 0, 16, 4, 1, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_O1, "f-o1", 0, 16, 5, 1, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_O2, "f-o2", 0, 16, 7, 2, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_I5, "f-i5", 0, 16, 9, 5, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_I6V, "f-i6v", 0, 16, 5, 6, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_I8, "f-i8", 0, 16, 12, 8, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_I8V, "f-i8v", 0, 16, 7, 8, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_I9, "f-i9", 0, 16, 9, 9, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_I10, "f-i10", 0, 16, 9, 10, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_I11, "f-i11", 0, 16, 10, 11, { 0, { (1<<MACH_BASE) } }  },
-  { NIOS_F_I6_REL_H, "f-i6-rel-h", 0, 16, 10, 6, { 0|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
-  { NIOS_F_I6_REL_W, "f-i6-rel-w", 0, 16, 10, 6, { 0|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
-  { NIOS_F_BSRR_I6_REL, "f-bsrr-i6-rel", 0, 16, 10, 6, { 0|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
-  { NIOS_F_I8V_REL_H, "f-i8v-rel-h", 0, 16, 7, 8, { 0|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
-  { NIOS_F_I8V_REL_W, "f-i8v-rel-w", 0, 16, 7, 8, { 0|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
-  { NIOS_F_I11_REL, "f-i11-rel", 0, 16, 10, 11, { 0|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
-  { NIOS_F_I1, "f-i1", 0, 16, 6, 2, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_NIL, "f-nil", 0, 0, 0, 0, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_ANYOF, "f-anyof", 0, 0, 0, 0, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_OP6, "f-op6", 0, 16, 15, 6, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_OP3, "f-op3", 0, 16, 15, 3, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_OP4, "f-op4", 0, 16, 15, 4, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_OP5, "f-op5", 0, 16, 15, 5, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_OP5_HI, "f-op5-hi", 16, 16, 15, 5, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_OP8, "f-op8", 0, 16, 15, 8, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_OP9, "f-op9", 0, 16, 15, 9, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_OP11, "f-op11", 0, 16, 15, 11, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_RA, "f-Ra", 0, 16, 4, 5, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_RB, "f-Rb", 0, 16, 9, 5, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_RBI5, "f-Rbi5", 0, 16, 9, 5, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_RZ, "f-Rz", 0, 16, 1, 2, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_RP, "f-Rp", 0, 16, 11, 2, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_CTLC, "f-CTLc", 0, 16, 4, 3, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I2, "f-i2", 0, 16, 6, 2, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I4W, "f-i4w", 0, 16, 3, 4, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_X1, "f-x1", 0, 16, 4, 1, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_O1, "f-o1", 0, 16, 5, 1, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_O2, "f-o2", 0, 16, 7, 2, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I5, "f-i5", 0, 16, 9, 5, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I6V, "f-i6v", 0, 16, 5, 6, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I8, "f-i8", 0, 16, 12, 8, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I8V, "f-i8v", 0, 16, 7, 8, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I9, "f-i9", 0, 16, 9, 9, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I10, "f-i10", 0, 16, 9, 10, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I11, "f-i11", 0, 16, 10, 11, { 0, { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I6_REL_H, "f-i6-rel-h", 0, 16, 10, 6, { 0|A(PCREL_ADDR), { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I6_REL_W, "f-i6-rel-w", 0, 16, 10, 6, { 0|A(PCREL_ADDR), { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_BSRR_I6_REL, "f-bsrr-i6-rel", 0, 16, 10, 6, { 0|A(PCREL_ADDR), { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I8V_REL_H, "f-i8v-rel-h", 0, 16, 7, 8, { 0|A(PCREL_ADDR), { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I8V_REL_W, "f-i8v-rel-w", 0, 16, 7, 8, { 0|A(PCREL_ADDR), { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I11_REL, "f-i11-rel", 0, 16, 10, 11, { 0|A(PCREL_ADDR), { { { (1<<MACH_BASE) } } } }  },
+  { NIOS_F_I1, "f-i1", 0, 16, 6, 2, { 0, { { { (1<<MACH_BASE) } } } }  },
   { 0 }
 };
 
@@ -384,170 +394,224 @@ const CGEN_IFLD nios_cgen_ifld_table[] =
 
 /* The operand table.  */
 
-#define A(a) (1 << CONCAT2 (CGEN_OPERAND_,a))
-#define OPERAND(op) CONCAT2 (NIOS_OPERAND_,op)
+#define A(a) (1 << CGEN_OPERAND_##a)
+#define OPERAND(op) NIOS_OPERAND_##op
 
 const CGEN_OPERAND nios_cgen_operand_table[] =
 {
 /* pc: program counter */
   { "pc", NIOS_OPERAND_PC, HW_H_PC, 0, 0,
-    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) &nios_cgen_ifld_table[NIOS_F_NIL] } },
+    { 0|A(SEM_ONLY), { { { (1<<MACH_BASE), 0 } } } }  },
 /* K: K register */
   { "K", NIOS_OPERAND_K, HW_H_K, 0, 0,
-    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(SEM_ONLY), { { { (1<<MACH_BASE), 0 } } } }  },
 /* CTLc: control register index */
   { "CTLc", NIOS_OPERAND_CTLC, HW_H_UINT, 4, 3,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* xRa: Ra ignored */
   { "xRa", NIOS_OPERAND_XRA, HW_H_UINT, 4, 5,
-    { 0, { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_BASE), 0 } } } }  },
 /* x1: 1 bit ignored */
   { "x1", NIOS_OPERAND_X1, HW_H_UINT, 4, 1,
-    { 0, { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_BASE), 0 } } } }  },
 /* o1: zero-bit */
   { "o1", NIOS_OPERAND_O1, HW_H_ZERO, 5, 1,
-    { 0, { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_BASE), 0 } } } }  },
 /* o2: 2 zero bits */
   { "o2", NIOS_OPERAND_O2, HW_H_ZERO, 7, 2,
-    { 0, { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_BASE), 0 } } } }  },
 /* i1: 1 bit unsigned immediate */
   { "i1", NIOS_OPERAND_I1, HW_H_UINT, 6, 2,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* i2: 2 bit unsigned immediate */
   { "i2", NIOS_OPERAND_I2, HW_H_UINT, 6, 2,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* si5: 5 bit signed immediate */
   { "si5", NIOS_OPERAND_SI5, HW_H_SINT, 9, 5,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* i8: 8 bit unsigned immediate */
   { "i8", NIOS_OPERAND_I8, HW_H_UINT, 12, 8,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* i8v: 8 bit unsigned immediate v */
   { "i8v", NIOS_OPERAND_I8V, HW_H_UINT, 7, 8,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* i6v: 6 bit unsigned immediate v */
   { "i6v", NIOS_OPERAND_I6V, HW_H_UINT, 5, 6,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* si11: 11 bit signed immediate */
   { "si11", NIOS_OPERAND_SI11, HW_H_SINT, 10, 11,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* rel11: 11 bit relative address */
   { "rel11", NIOS_OPERAND_REL11, HW_H_IADDR, 10, 11,
-    { 0|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(PCREL_ADDR), { { { (1<<MACH_BASE), 0 } } } }  },
 /* bsrr_rel6: dummy 6 bit relative address */
   { "bsrr_rel6", NIOS_OPERAND_BSRR_REL6, HW_H_IADDR, 10, 6,
-    { 0|A(RELAX)|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(RELAX)|A(PCREL_ADDR), { { { (1<<MACH_BASE), 0 } } } }  },
 /* nbit: negative    bit */
   { "nbit", NIOS_OPERAND_NBIT, HW_H_NBIT, 0, 0,
-    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(SEM_ONLY), { { { (1<<MACH_BASE), 0 } } } }  },
 /* vbit: overflow    bit */
   { "vbit", NIOS_OPERAND_VBIT, HW_H_VBIT, 0, 0,
-    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(SEM_ONLY), { { { (1<<MACH_BASE), 0 } } } }  },
 /* zbit: zero        bit */
   { "zbit", NIOS_OPERAND_ZBIT, HW_H_ZBIT, 0, 0,
-    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(SEM_ONLY), { { { (1<<MACH_BASE), 0 } } } }  },
 /* cbit: carry       bit */
   { "cbit", NIOS_OPERAND_CBIT, HW_H_CBIT, 0, 0,
-    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(SEM_ONLY), { { { (1<<MACH_BASE), 0 } } } }  },
 /* tebit: trap-enable bit */
   { "tebit", NIOS_OPERAND_TEBIT, HW_H_TEBIT, 0, 0,
-    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(SEM_ONLY), { { { (1<<MACH_BASE), 0 } } } }  },
 /* pbit: prefix      bit */
   { "pbit", NIOS_OPERAND_PBIT, HW_H_PBIT, 0, 0,
-    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(SEM_ONLY), { { { (1<<MACH_BASE), 0 } } } }  },
 /* sbit: skip        bit */
   { "sbit", NIOS_OPERAND_SBIT, HW_H_SBIT, 0, 0,
-    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(SEM_ONLY), { { { (1<<MACH_BASE), 0 } } } }  },
 /* wbit: window chg  bit */
   { "wbit", NIOS_OPERAND_WBIT, HW_H_WBIT, 0, 0,
-    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(SEM_ONLY), { { { (1<<MACH_BASE), 0 } } } }  },
 /* i4w: 4 bit condition code index */
   { "i4w", NIOS_OPERAND_I4W, HW_H_UINT, 3, 4,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* i4wn: 4 bit condition code index reversed */
   { "i4wn", NIOS_OPERAND_I4WN, HW_H_UINT, 3, 4,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* i5: 5 bit unsigned immediate */
   { "i5", NIOS_OPERAND_I5, HW_H_UINT, 9, 5,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* save_i8v: 8 bit unsigned immediate for save insn */
   { "save_i8v", NIOS_OPERAND_SAVE_I8V, HW_H_UINT, 7, 8,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* i11: 11 bit unsigned immediate */
   { "i11", NIOS_OPERAND_I11, HW_H_UINT, 10, 11,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* i10: 10 bit unsigned immediate */
   { "i10", NIOS_OPERAND_I10, HW_H_UINT, 9, 10,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* i9: 9 bit unsigned immediate */
   { "i9", NIOS_OPERAND_I9, HW_H_UINT, 9, 9,
-    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX), { { { (1<<MACH_BASE), 0 } } } }  },
 /* i16: 16 bit unsigned immediate */
   { "i16", NIOS_OPERAND_I16, HW_H_UINT, 0, 0,
-    { 0|A(HASH_PREFIX)|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX)|A(SEM_ONLY), { { { (1<<MACH_BASE), 0 } } } }  },
 /* i32: 32 bit unsigned immediate */
   { "i32", NIOS_OPERAND_I32, HW_H_UINT, 0, 0,
-    { 0|A(HASH_PREFIX)|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(HASH_PREFIX)|A(SEM_ONLY), { { { (1<<MACH_BASE), 0 } } } }  },
 /* Rbi5: 5 bit register or unsigned immediate */
   { "Rbi5", NIOS_OPERAND_RBI5, HW_H_UINT, 9, 5,
-    { 0, { (1<<MACH_BASE) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_BASE), 0 } } } }  },
 /* m16_Ra: source register a */
   { "m16_Ra", NIOS_OPERAND_M16_RA, HW_H_M16_GR, 4, 5,
-    { 0, { (1<<MACH_NIOS16) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_NIOS16), 0 } } } }  },
 /* m16_Rb: source register b */
   { "m16_Rb", NIOS_OPERAND_M16_RB, HW_H_M16_GR, 9, 5,
-    { 0, { (1<<MACH_NIOS16) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_NIOS16), 0 } } } }  },
 /* m16_R0: source register 0 */
   { "m16_R0", NIOS_OPERAND_M16_R0, HW_H_M16_GR0, 0, 0,
-    { 0, { (1<<MACH_NIOS16) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_NIOS16), 0 } } } }  },
 /* m16_sp: stack pointer */
   { "m16_sp", NIOS_OPERAND_M16_SP, HW_H_M16_SP, 0, 0,
-    { 0, { (1<<MACH_NIOS16) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_NIOS16), 0 } } } }  },
 /* m16_Rp: base pointer register */
   { "m16_Rp", NIOS_OPERAND_M16_RP, HW_H_M16_BP, 11, 2,
-    { 0, { (1<<MACH_NIOS16) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_NIOS16), 0 } } } }  },
 /* m16_Rz: ctl target register */
   { "m16_Rz", NIOS_OPERAND_M16_RZ, HW_H_M16_RZ, 1, 2,
-    { 0, { (1<<MACH_NIOS16) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_NIOS16), 0 } } } }  },
 /* m16_i6: 6-bit half-word pc rel */
   { "m16_i6", NIOS_OPERAND_M16_I6, HW_H_IADDR, 10, 6,
-    { 0|A(PCREL_ADDR), { (1<<MACH_NIOS16) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(PCREL_ADDR), { { { (1<<MACH_NIOS16), 0 } } } }  },
 /* m16_i8v: 8-bit half-word pc rel */
   { "m16_i8v", NIOS_OPERAND_M16_I8V, HW_H_IADDR, 7, 8,
-    { 0|A(PCREL_ADDR), { (1<<MACH_NIOS16) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(PCREL_ADDR), { { { (1<<MACH_NIOS16), 0 } } } }  },
 /* m32_Ra: source register a */
   { "m32_Ra", NIOS_OPERAND_M32_RA, HW_H_M32_GR, 4, 5,
-    { 0, { (1<<MACH_NIOS32) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_NIOS32), 0 } } } }  },
 /* m32_Rb: source register b */
   { "m32_Rb", NIOS_OPERAND_M32_RB, HW_H_M32_GR, 9, 5,
-    { 0, { (1<<MACH_NIOS32) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_NIOS32), 0 } } } }  },
 /* m32_R0: source register 0 */
   { "m32_R0", NIOS_OPERAND_M32_R0, HW_H_M32_GR0, 0, 0,
-    { 0, { (1<<MACH_NIOS32) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_NIOS32), 0 } } } }  },
 /* m32_sp: stack pointer */
   { "m32_sp", NIOS_OPERAND_M32_SP, HW_H_M32_SP, 0, 0,
-    { 0, { (1<<MACH_NIOS32) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_NIOS32), 0 } } } }  },
 /* m32_Rp: base pointer register */
   { "m32_Rp", NIOS_OPERAND_M32_RP, HW_H_M32_BP, 11, 2,
-    { 0, { (1<<MACH_NIOS32) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_NIOS32), 0 } } } }  },
 /* m32_Rz: ctl target register */
   { "m32_Rz", NIOS_OPERAND_M32_RZ, HW_H_M32_RZ, 1, 2,
-    { 0, { (1<<MACH_NIOS32) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_NIOS32), 0 } } } }  },
 /* m32_i6: 6-bit word pc rel */
   { "m32_i6", NIOS_OPERAND_M32_I6, HW_H_IADDR, 10, 6,
-    { 0|A(PCREL_ADDR), { (1<<MACH_NIOS32) } }  },
+    { 0, { (const PTR) 0 } },
+    { 0|A(PCREL_ADDR), { { { (1<<MACH_NIOS32), 0 } } } }  },
 /* m32_i8v: 8-bit word pc rel */
   { "m32_i8v", NIOS_OPERAND_M32_I8V, HW_H_IADDR, 7, 8,
-    { 0|A(PCREL_ADDR), { (1<<MACH_NIOS32) } }  },
-  { 0 }
+    { 0, { (const PTR) 0 } },
+    { 0|A(PCREL_ADDR), { { { (1<<MACH_NIOS32), 0 } } } }  },
+/* sentinel */
+  { 0, 0, 0, 0, 0,
+    { 0, { (const PTR) 0 } },
+    { 0, { { { (1<<MACH_NIOS32), 0 } } } } }
 };
 
 #undef A
 
-#define A(a) (1 << CONCAT2 (CGEN_INSN_,a))
-#define OP(field) CGEN_SYNTAX_MAKE_FIELD (OPERAND (field))
 
 /* The instruction table.  */
+
+#define OP(field) CGEN_SYNTAX_MAKE_FIELD (OPERAND (field))
+#define A(a) (1 << CGEN_INSN_##a)
 
 static const CGEN_IBASE nios_cgen_insn_table[MAX_INSNS] =
 {
@@ -558,692 +622,701 @@ static const CGEN_IBASE nios_cgen_insn_table[MAX_INSNS] =
 /* ext8s $m16_Ra,$i1 */
   {
     NIOS_INSN_EXT8S16, "ext8s16", "ext8s", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* st8s [$m16_Ra],$m16_R0,$i1 */
   {
     NIOS_INSN_ST8S16, "st8s16", "st8s", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS16) } } } }
   },
 /* sts8s [$m16_sp,$i10],$m16_R0 */
   {
     NIOS_INSN_STS8S16, "sts8s16", "sts8s", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* st8d [$m16_Ra],$m16_R0 */
   {
     NIOS_INSN_ST8D16, "st8d16", "st8d", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* wrctl $m16_Ra */
   {
     NIOS_INSN_WRCTL16, "wrctl16", "wrctl", 16,
-    { 0|A(DELAY_SLOT)|A(COND_CTI), { (1<<MACH_NIOS16) } }
+    { 0|A(DELAY_SLOT)|A(COND_CTI), { { { (1<<MACH_NIOS16) } } } }
   },
 /* addc $m16_Ra,$m16_Rb */
   {
     NIOS_INSN_ADDC16, "addc16", "addc", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* subc $m16_Ra,$m16_Rb */
   {
     NIOS_INSN_SUBC16, "subc16", "subc", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* add $m16_Ra,$m16_Rb */
   {
     NIOS_INSN_ADD16, "add16", "add", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* sub $m16_Ra,$m16_Rb */
   {
     NIOS_INSN_SUB16, "sub16", "sub", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* addi $m16_Ra,$i5 */
   {
     NIOS_INSN_ADDI16, "addi16", "addi", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS16) } } } }
   },
 /* subi $m16_Ra,$i5 */
   {
     NIOS_INSN_SUBI16, "subi16", "subi", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS16) } } } }
   },
 /* or $m16_Ra,$Rbi5 */
   {
     NIOS_INSN_OR16, "or16", "or", 16,
-    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { { { (1<<MACH_NIOS16) } } } }
   },
 /* xor $m16_Ra,$Rbi5 */
   {
     NIOS_INSN_XOR16, "xor16", "xor", 16,
-    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { { { (1<<MACH_NIOS16) } } } }
   },
 /* and $m16_Ra,$Rbi5 */
   {
     NIOS_INSN_AND16, "and16", "and", 16,
-    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { { { (1<<MACH_NIOS16) } } } }
   },
 /* andn $m16_Ra,$Rbi5 */
   {
     NIOS_INSN_ANDN16, "andn16", "andn", 16,
-    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { { { (1<<MACH_NIOS16) } } } }
   },
 /* lsl $m16_Ra,$m16_Rb */
   {
     NIOS_INSN_LSL16, "lsl16", "lsl", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* lsr $m16_Ra,$m16_Rb */
   {
     NIOS_INSN_LSR16, "lsr16", "lsr", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* asr $m16_Ra,$m16_Rb */
   {
     NIOS_INSN_ASR16, "asr16", "asr", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* lsli $m16_Ra,$i5 */
   {
     NIOS_INSN_LSLI16, "lsli16", "lsli", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* lsri $m16_Ra,$i5 */
   {
     NIOS_INSN_LSRI16, "lsri16", "lsri", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* asri $m16_Ra,$i5 */
   {
     NIOS_INSN_ASRI16, "asri16", "asri", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* not $m16_Ra */
   {
     NIOS_INSN_NOT16, "not16", "not", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* neg $m16_Ra */
   {
     NIOS_INSN_NEG16, "neg16", "neg", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* abs $m16_Ra */
   {
     NIOS_INSN_ABS16, "abs16", "abs", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* mov $m16_Ra,$m16_Rb */
   {
     NIOS_INSN_MOV16, "mov16", "mov", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* movi $m16_Ra,$i5 */
   {
     NIOS_INSN_MOVI16, "movi16", "movi", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS16) } } } }
   },
 /* bgen $m16_Ra,$i5 */
   {
     NIOS_INSN_BGEN16, "bgen16", "bgen", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* cmp $m16_Ra,$m16_Rb */
   {
     NIOS_INSN_CMP16, "cmp16", "cmp", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* cmpi $m16_Ra,$i5 */
   {
     NIOS_INSN_CMPI16, "cmpi16", "cmpi", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS16) } } } }
   },
 /* ext8d $m16_Ra,$m16_Rb */
   {
     NIOS_INSN_EXT8D16, "ext8d16", "ext8d", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* sext8 $m16_Ra */
   {
     NIOS_INSN_SEXT816, "sext816", "sext8", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* fill8 $m16_R0,$m16_Ra */
   {
     NIOS_INSN_FILL816, "fill816", "fill8", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* lds $m16_Ra,[$m16_sp,$i8] */
   {
     NIOS_INSN_LDS16, "lds16", "lds", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* sts [$m16_sp,$i8],$m16_Ra */
   {
     NIOS_INSN_STS16, "sts16", "sts", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* ldp $m16_Ra,[$m16_Rp,$i5] */
   {
     NIOS_INSN_LDP16, "ldp16", "ldp", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS16) } } } }
   },
 /* stp [$m16_Rp,$i5],$m16_Ra */
   {
     NIOS_INSN_STP16, "stp16", "stp", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS16) } } } }
   },
 /* ld $m16_Ra,[$m16_Rb] */
   {
     NIOS_INSN_LD16, "ld16", "ld", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS16) } } } }
   },
 /* st [$m16_Rb],$m16_Ra */
   {
     NIOS_INSN_ST16, "st16", "st", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS16) } } } }
   },
 /* trap $i6v */
   {
     NIOS_INSN_TRAP16, "trap16", "trap", 16,
-    { 0|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+    { 0|A(UNCOND_CTI), { { { (1<<MACH_NIOS16) } } } }
   },
 /* tret $m16_Ra */
   {
     NIOS_INSN_TRET16, "tret16", "tret", 16,
-    { 0|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+    { 0|A(UNCOND_CTI), { { { (1<<MACH_NIOS16) } } } }
   },
 /* save $m16_sp,$save_i8v */
   {
     NIOS_INSN_SAVE16, "save16", "save", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* restore */
   {
     NIOS_INSN_RESTORE16, "restore16", "restore", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* bsr $rel11 */
   {
     NIOS_INSN_BSR16, "bsr16", "bsr", 16,
-    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { { { (1<<MACH_NIOS16) } } } }
   },
 /* bsrr $m16_Ra,$bsrr_rel6 */
   {
     NIOS_INSN_BSRR16, "bsrr16", "bsrr", 16,
-    { 0|A(RELAXABLE)|A(NO_DIS)|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+    { 0|A(RELAXABLE)|A(NO_DIS)|A(DELAY_SLOT)|A(UNCOND_CTI), { { { (1<<MACH_NIOS16) } } } }
   },
 /* jmp $m16_Ra */
   {
     NIOS_INSN_JMP16, "jmp16", "jmp", 16,
-    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { { { (1<<MACH_NIOS16) } } } }
   },
 /* call $m16_Ra */
   {
     NIOS_INSN_CALL16, "call16", "call", 16,
-    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { { { (1<<MACH_NIOS16) } } } }
   },
 /* jmpc [$m16_i8v] */
   {
     NIOS_INSN_JMPC16, "jmpc16", "jmpc", 16,
-    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { { { (1<<MACH_NIOS16) } } } }
   },
 /* callc [$m16_i8v] */
   {
     NIOS_INSN_CALLC16, "callc16", "callc", 16,
-    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { { { (1<<MACH_NIOS16) } } } }
   },
 /* skp0 $m16_Ra,$i5 */
   {
     NIOS_INSN_SKP016, "skp016", "skp0", 16,
-    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS16) } }
+    { 0|A(SKIP_INSN)|A(COND_CTI), { { { (1<<MACH_NIOS16) } } } }
   },
 /* skp1 $m16_Ra,$i5 */
   {
     NIOS_INSN_SKP116, "skp116", "skp1", 16,
-    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS16) } }
+    { 0|A(SKIP_INSN)|A(COND_CTI), { { { (1<<MACH_NIOS16) } } } }
   },
 /* skprz $m16_Ra */
   {
     NIOS_INSN_SKPRZ16, "skprz16", "skprz", 16,
-    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS16) } }
+    { 0|A(SKIP_INSN)|A(COND_CTI), { { { (1<<MACH_NIOS16) } } } }
   },
 /* skprnz $m16_Ra */
   {
     NIOS_INSN_SKPRNZ16, "skprnz16", "skprnz", 16,
-    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS16) } }
+    { 0|A(SKIP_INSN)|A(COND_CTI), { { { (1<<MACH_NIOS16) } } } }
   },
 /* skps $i4w */
   {
     NIOS_INSN_SKPS16, "skps16", "skps", 16,
-    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS16) } }
+    { 0|A(SKIP_INSN)|A(COND_CTI), { { { (1<<MACH_NIOS16) } } } }
   },
 /* rrc $m16_Ra */
   {
     NIOS_INSN_RRC16, "rrc16", "rrc", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* rlc $m16_Ra */
   {
     NIOS_INSN_RLC16, "rlc16", "rlc", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* rdctl $m16_Ra */
   {
     NIOS_INSN_RDCTL16, "rdctl16", "rdctl", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* usr0 $m16_Ra */
   {
     NIOS_INSN_USR016, "usr016", "usr0", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* usr1 $m16_Ra,$m16_R0 */
   {
     NIOS_INSN_USR116, "usr116", "usr1", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* usr2 $m16_Ra,$m16_R0 */
   {
     NIOS_INSN_USR216, "usr216", "usr2", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* usr3 $m16_Ra,$m16_R0 */
   {
     NIOS_INSN_USR316, "usr316", "usr3", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* usr4 $m16_Ra,$m16_R0 */
   {
     NIOS_INSN_USR416, "usr416", "usr4", 16,
-    { 0, { (1<<MACH_NIOS16) } }
+    { 0, { { { (1<<MACH_NIOS16) } } } }
   },
 /* sts8s [$m32_sp,$i10],$m32_R0 */
   {
     NIOS_INSN_STS8S32, "sts8s32", "sts8s", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* sts16s [$m32_sp,$i9],$m32_R0 */
   {
     NIOS_INSN_STS16S, "sts16s", "sts16s", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* movhi $m32_Ra,$i5 */
   {
     NIOS_INSN_MOVHI, "movhi", "movhi", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* ext16d $m32_Ra,$m32_Rb */
   {
     NIOS_INSN_EXT16D, "ext16d", "ext16d", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* sext16 $m32_Ra */
   {
     NIOS_INSN_SEXT16, "sext16", "sext16", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* st16d [$m32_Ra],$m32_R0 */
   {
     NIOS_INSN_ST16D, "st16d", "st16d", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* fill16 $m32_R0,$m32_Ra */
   {
     NIOS_INSN_FILL16, "fill16", "fill16", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* ext8s $m32_Ra,$i2 */
   {
     NIOS_INSN_EXT8S32, "ext8s32", "ext8s", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* st8s [$m32_Ra],$m32_R0,$i2 */
   {
     NIOS_INSN_ST8S32, "st8s32", "st8s", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* ext16s $m32_Ra,$i1 */
   {
     NIOS_INSN_EXT16S, "ext16s", "ext16s", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* st16s [$m32_Ra],$m32_R0,$i1 */
   {
     NIOS_INSN_ST16S, "st16s", "st16s", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* st8d [$m32_Ra],$m32_R0 */
   {
     NIOS_INSN_ST8D32, "st8d32", "st8d", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* wrctl $m32_Ra */
   {
     NIOS_INSN_WRCTL32, "wrctl32", "wrctl", 16,
-    { 0|A(DELAY_SLOT)|A(COND_CTI), { (1<<MACH_NIOS32) } }
+    { 0|A(DELAY_SLOT)|A(COND_CTI), { { { (1<<MACH_NIOS32) } } } }
   },
 /* add $m32_Ra,$m32_Rb */
   {
     NIOS_INSN_ADD32, "add32", "add", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* sub $m32_Ra,$m32_Rb */
   {
     NIOS_INSN_SUB32, "sub32", "sub", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* addi $m32_Ra,$i5 */
   {
     NIOS_INSN_ADDI32, "addi32", "addi", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* subi $m32_Ra,$i5 */
   {
     NIOS_INSN_SUBI32, "subi32", "subi", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* or $m32_Ra,$Rbi5 */
   {
     NIOS_INSN_OR32, "or32", "or", 16,
-    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* xor $m32_Ra,$Rbi5 */
   {
     NIOS_INSN_XOR32, "xor32", "xor", 16,
-    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* and $m32_Ra,$Rbi5 */
   {
     NIOS_INSN_AND32, "and32", "and", 16,
-    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* andn $m32_Ra,$Rbi5 */
   {
     NIOS_INSN_ANDN32, "andn32", "andn", 16,
-    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* lsl $m32_Ra,$m32_Rb */
   {
     NIOS_INSN_LSL32, "lsl32", "lsl", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* lsr $m32_Ra,$m32_Rb */
   {
     NIOS_INSN_LSR32, "lsr32", "lsr", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* asr $m32_Ra,$m32_Rb */
   {
     NIOS_INSN_ASR32, "asr32", "asr", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* lsli $m32_Ra,$i5 */
   {
     NIOS_INSN_LSLI32, "lsli32", "lsli", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* lsri $m32_Ra,$i5 */
   {
     NIOS_INSN_LSRI32, "lsri32", "lsri", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* asri $m32_Ra,$i5 */
   {
     NIOS_INSN_ASRI32, "asri32", "asri", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* not $m32_Ra */
   {
     NIOS_INSN_NOT32, "not32", "not", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* neg $m32_Ra */
   {
     NIOS_INSN_NEG32, "neg32", "neg", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { {(1<<MACH_NIOS32) } } } }
   },
 /* abs $m32_Ra */
   {
     NIOS_INSN_ABS32, "abs32", "abs", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* mov $m32_Ra,$m32_Rb */
   {
     NIOS_INSN_MOV32, "mov32", "mov", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* movi $m32_Ra,$i5 */
   {
     NIOS_INSN_MOVI32, "movi32", "movi", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* bgen $m32_Ra,$i5 */
   {
     NIOS_INSN_BGEN32, "bgen32", "bgen", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* cmp $m32_Ra,$m32_Rb */
   {
     NIOS_INSN_CMP32, "cmp32", "cmp", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* cmpi $m32_Ra,$i5 */
   {
     NIOS_INSN_CMPI32, "cmpi32", "cmpi", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* ext8d $m32_Ra,$m32_Rb */
   {
     NIOS_INSN_EXT8D32, "ext8d32", "ext8d", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* sext8 $m32_Ra */
   {
     NIOS_INSN_SEXT832, "sext832", "sext8", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* fill8 $m32_R0,$m32_Ra */
   {
     NIOS_INSN_FILL832, "fill832", "fill8", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* lds $m32_Ra,[$m32_sp,$i8] */
   {
     NIOS_INSN_LDS32, "lds32", "lds", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* sts [$m32_sp,$i8],$m32_Ra */
   {
     NIOS_INSN_STS32, "sts32", "sts", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* ldp $m32_Ra,[$m32_Rp,$i5] */
   {
     NIOS_INSN_LDP32, "ldp32", "ldp", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* stp [$m32_Rp,$i5],$m32_Ra */
   {
     NIOS_INSN_STP32, "stp32", "stp", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* ld $m32_Ra,[$m32_Rb] */
   {
     NIOS_INSN_LD32, "ld32", "ld", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* st [$m32_Rb],$m32_Ra */
   {
     NIOS_INSN_ST32, "st32", "st", 16,
-    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+    { 0|A(PREFIXED_INSN), { { { (1<<MACH_NIOS32) } } } }
   },
 /* trap $i6v */
   {
     NIOS_INSN_TRAP32, "trap32", "trap", 16,
-    { 0|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+    { 0|A(UNCOND_CTI), { { { (1<<MACH_NIOS32) } } } }
   },
 /* tret $m32_Ra */
   {
     NIOS_INSN_TRET32, "tret32", "tret", 16,
-    { 0|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+    { 0|A(UNCOND_CTI), { { { (1<<MACH_NIOS32) } } } }
   },
 /* save $m32_sp,$save_i8v */
   {
     NIOS_INSN_SAVE32, "save32", "save", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* restore */
   {
     NIOS_INSN_RESTORE32, "restore32", "restore", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* bsr $rel11 */
   {
     NIOS_INSN_BSR32, "bsr32", "bsr", 16,
-    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { { { (1<<MACH_NIOS32) } } } }
   },
 /* bsrr $m32_Ra,$bsrr_rel6 */
   {
     NIOS_INSN_BSRR32, "bsrr32", "bsrr", 16,
-    { 0|A(RELAXABLE)|A(NO_DIS)|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+    { 0|A(RELAXABLE)|A(NO_DIS)|A(DELAY_SLOT)|A(UNCOND_CTI), { { { (1<<MACH_NIOS32) } } } }
   },
 /* jmp $m32_Ra */
   {
     NIOS_INSN_JMP32, "jmp32", "jmp", 16,
-    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { { { (1<<MACH_NIOS32) } } } }
   },
 /* call $m32_Ra */
   {
     NIOS_INSN_CALL32, "call32", "call", 16,
-    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { { { (1<<MACH_NIOS32) } } } }
   },
 /* jmpc [$m32_i8v] */
   {
     NIOS_INSN_JMPC32, "jmpc32", "jmpc", 16,
-    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { { { (1<<MACH_NIOS32) } } } }
   },
 /* callc [$m32_i8v] */
   {
     NIOS_INSN_CALLC32, "callc32", "callc", 16,
-    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { { { (1<<MACH_NIOS32) } } } }
   },
 /* skp0 $m32_Ra,$i5 */
   {
     NIOS_INSN_SKP032, "skp032", "skp0", 16,
-    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS32) } }
+    { 0|A(SKIP_INSN)|A(COND_CTI), { { { (1<<MACH_NIOS32) } } } }
   },
 /* skp1 $m32_Ra,$i5 */
   {
     NIOS_INSN_SKP132, "skp132", "skp1", 16,
-    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS32) } }
+    { 0|A(SKIP_INSN)|A(COND_CTI), { { { (1<<MACH_NIOS32) } } } }
   },
 /* skprz $m32_Ra */
   {
     NIOS_INSN_SKPRZ32, "skprz32", "skprz", 16,
-    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS32) } }
+    { 0|A(SKIP_INSN)|A(COND_CTI), { { { (1<<MACH_NIOS32) } } } }
   },
 /* skprnz $m32_Ra */
   {
     NIOS_INSN_SKPRNZ32, "skprnz32", "skprnz", 16,
-    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS32) } }
+    { 0|A(SKIP_INSN)|A(COND_CTI), { { { (1<<MACH_NIOS32) } } } }
   },
 /* skps $i4w */
   {
     NIOS_INSN_SKPS32, "skps32", "skps", 16,
-    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS32) } }
+    { 0|A(SKIP_INSN)|A(COND_CTI), { { { (1<<MACH_NIOS32) } } } }
   },
 /* rrc $m32_Ra */
   {
     NIOS_INSN_RRC32, "rrc32", "rrc", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* rlc $m32_Ra */
   {
     NIOS_INSN_RLC32, "rlc32", "rlc", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* rdctl $m32_Ra */
   {
     NIOS_INSN_RDCTL32, "rdctl32", "rdctl", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* pfx $i11 */
   {
     NIOS_INSN_PFX, "pfx", "pfx", 16,
-    { 0|A(PREFIX), { (1<<MACH_BASE) } }
+    { 0|A(PREFIX), { { { (1<<MACH_BASE) } } } }
   },
 /* br $rel11 */
   {
     NIOS_INSN_BR, "br", "br", 16,
-    { 0|A(UNCOND_CTI)|A(DELAY_SLOT), { (1<<MACH_BASE) } }
+    { 0|A(UNCOND_CTI)|A(DELAY_SLOT), { { { (1<<MACH_BASE) } } } }
   },
 /* swap $m32_Ra */
   {
     NIOS_INSN_SWAP32, "swap32", "swap", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* mstep $m32_Ra */
   {
     NIOS_INSN_RRC32, "mstep32", "mstep", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* mul $m32_Ra */
   {
     NIOS_INSN_RRC32, "mul32", "mul", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* usr0 $m32_Ra,$m32_Rb */
   {
     NIOS_INSN_USR032, "usr032", "usr0", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* usr1 [$m32_Ra],$m32_R0 */
   {
     NIOS_INSN_USR132, "usr132", "usr1", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* usr2 [$m32_Ra],$m32_R0 */
   {
     NIOS_INSN_USR232, "usr232", "usr2", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* usr3 [$m32_Ra],$m32_R0 */
   {
     NIOS_INSN_USR332, "usr332", "usr3", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* usr4 [$m32_Ra],$m32_R0 */
   {
     NIOS_INSN_USR432, "usr432", "usr4", 16,
-    { 0, { (1<<MACH_NIOS32) } }
+    { 0, { { { (1<<MACH_NIOS32) } } } }
   },
 /* pfxio $i11 */
   {
     NIOS_INSN_PFXIO, "pfxio", "pfxio", 16,
-    { 0|A(PREFIX), { (1<<MACH_BASE) } }
+    { 0|A(PREFIX), { { { (1<<MACH_BASE) } } } }
   },
 };
 
-#undef A
-#undef MNEM
 #undef OP
+#undef A
 
 /* Initialize anything needed to be done once, before any cpu_open call.  */
 
 static void
-init_tables ()
+init_tables (void)
 {
 }
+
+#ifndef opcodes_error_handler
+#define opcodes_error_handler(...) \
+  fprintf (stderr, __VA_ARGS__); fputc ('\n', stderr)
+#endif
+
+static const CGEN_MACH * lookup_mach_via_bfd_name (const CGEN_MACH *, const char *);
+static void build_hw_table      (CGEN_CPU_TABLE *);
+static void build_ifield_table  (CGEN_CPU_TABLE *);
+static void build_operand_table (CGEN_CPU_TABLE *);
+static void build_insn_table    (CGEN_CPU_TABLE *);
+static void nios_cgen_rebuild_tables (CGEN_CPU_TABLE *);
 
 /* Subroutine of nios_cgen_cpu_open to look up a mach via its bfd name.  */
 
 static const CGEN_MACH *
-lookup_mach_via_bfd_name (table, name)
-     const CGEN_MACH *table;
-     const char *name;
+lookup_mach_via_bfd_name (const CGEN_MACH *table, const char *name)
 {
   while (table->name)
     {
@@ -1251,14 +1324,13 @@ lookup_mach_via_bfd_name (table, name)
 	return table;
       ++table;
     }
-  abort ();
+  return NULL;
 }
 
 /* Subroutine of nios_cgen_cpu_open to build the hardware table.  */
 
 static void
-build_hw_table (cd)
-     CGEN_CPU_TABLE *cd;
+build_hw_table (CGEN_CPU_TABLE *cd)
 {
   int i;
   int machs = cd->machs;
@@ -1284,8 +1356,7 @@ build_hw_table (cd)
 /* Subroutine of nios_cgen_cpu_open to build the hardware table.  */
 
 static void
-build_ifield_table (cd)
-     CGEN_CPU_TABLE *cd;
+build_ifield_table (CGEN_CPU_TABLE *cd)
 {
   cd->ifld_table = & nios_cgen_ifld_table[0];
 }
@@ -1293,8 +1364,7 @@ build_ifield_table (cd)
 /* Subroutine of nios_cgen_cpu_open to build the hardware table.  */
 
 static void
-build_operand_table (cd)
-     CGEN_CPU_TABLE *cd;
+build_operand_table (CGEN_CPU_TABLE *cd)
 {
   int i;
   int machs = cd->machs;
@@ -1302,8 +1372,7 @@ build_operand_table (cd)
   /* MAX_OPERANDS is only an upper bound on the number of selected entries.
      However each entry is indexed by it's enum so there can be holes in
      the table.  */
-  const CGEN_OPERAND **selected =
-    (const CGEN_OPERAND **) xmalloc (MAX_OPERANDS * sizeof (CGEN_OPERAND *));
+  const CGEN_OPERAND **selected = xmalloc (MAX_OPERANDS * sizeof (* selected));
 
   cd->operand_table.init_entries = init;
   cd->operand_table.entry_size = sizeof (CGEN_OPERAND);
@@ -1326,12 +1395,11 @@ build_operand_table (cd)
    operand elements to be in the table [which they mightn't be].  */
 
 static void
-build_insn_table (cd)
-     CGEN_CPU_TABLE *cd;
+build_insn_table (CGEN_CPU_TABLE *cd)
 {
   int i;
   const CGEN_IBASE *ib = & nios_cgen_insn_table[0];
-  CGEN_INSN *insns = (CGEN_INSN *) xmalloc (MAX_INSNS * sizeof (CGEN_INSN));
+  CGEN_INSN *insns = xmalloc (MAX_INSNS * sizeof (CGEN_INSN));
 
   memset (insns, 0, MAX_INSNS * sizeof (CGEN_INSN));
   for (i = 0; i < MAX_INSNS; ++i)
@@ -1344,11 +1412,10 @@ build_insn_table (cd)
 /* Subroutine of nios_cgen_cpu_open to rebuild the tables.  */
 
 static void
-nios_cgen_rebuild_tables (cd)
-     CGEN_CPU_TABLE *cd;
+nios_cgen_rebuild_tables (CGEN_CPU_TABLE *cd)
 {
-  int i,n_isas,n_machs;
-  unsigned int isas = cd->isas;
+  int i;
+  CGEN_BITSET *isas = cd->isas;
   unsigned int machs = cd->machs;
 
   cd->int_insn_p = CGEN_INT_INSN_P;
@@ -1357,28 +1424,28 @@ nios_cgen_rebuild_tables (cd)
 #define UNSET (CGEN_SIZE_UNKNOWN + 1)
   cd->default_insn_bitsize = UNSET;
   cd->base_insn_bitsize = UNSET;
-  cd->min_insn_bitsize = 65535; /* some ridiculously big number */
+  cd->min_insn_bitsize = 65535; /* Some ridiculously big number.  */
   cd->max_insn_bitsize = 0;
   for (i = 0; i < MAX_ISAS; ++i)
-    if (((1 << i) & isas) != 0)
+    if (cgen_bitset_contains (isas, i))
       {
 	const CGEN_ISA *isa = & nios_cgen_isa_table[i];
 
-	/* Default insn sizes of all selected isas must be equal or we set
-	   the result to 0, meaning "unknown".  */
+	/* Default insn sizes of all selected isas must be
+	   equal or we set the result to 0, meaning "unknown".  */
 	if (cd->default_insn_bitsize == UNSET)
 	  cd->default_insn_bitsize = isa->default_insn_bitsize;
 	else if (isa->default_insn_bitsize == cd->default_insn_bitsize)
-	  ; /* this is ok */
+	  ; /* This is ok.  */
 	else
 	  cd->default_insn_bitsize = CGEN_SIZE_UNKNOWN;
 
-	/* Base insn sizes of all selected isas must be equal or we set
-	   the result to 0, meaning "unknown".  */
+	/* Base insn sizes of all selected isas must be equal
+	   or we set the result to 0, meaning "unknown".  */
 	if (cd->base_insn_bitsize == UNSET)
 	  cd->base_insn_bitsize = isa->base_insn_bitsize;
 	else if (isa->base_insn_bitsize == cd->base_insn_bitsize)
-	  ; /* this is ok */
+	  ; /* This is ok.  */
 	else
 	  cd->base_insn_bitsize = CGEN_SIZE_UNKNOWN;
 
@@ -1387,8 +1454,6 @@ nios_cgen_rebuild_tables (cd)
 	  cd->min_insn_bitsize = isa->min_insn_bitsize;
 	if (isa->max_insn_bitsize > cd->max_insn_bitsize)
 	  cd->max_insn_bitsize = isa->max_insn_bitsize;
-
-	++n_isas;
       }
 
   /* Data derived from the mach spec.  */
@@ -1397,7 +1462,20 @@ nios_cgen_rebuild_tables (cd)
       {
 	const CGEN_MACH *mach = & nios_cgen_mach_table[i];
 
-	++n_machs;
+	if (mach->insn_chunk_bitsize != 0)
+	{
+	  if (cd->insn_chunk_bitsize != 0 && cd->insn_chunk_bitsize != mach->insn_chunk_bitsize)
+	    {
+	      opcodes_error_handler
+		(/* xgettext:c-format */
+		 _("internal error: nios_cgen_rebuild_tables: "
+		   "conflicting insn-chunk-bitsize values: `%d' vs. `%d'"),
+		 cd->insn_chunk_bitsize, mach->insn_chunk_bitsize);
+	      abort ();
+	    }
+
+	  cd->insn_chunk_bitsize = mach->insn_chunk_bitsize;
+	}
       }
 
   /* Determine which hw elements are used by MACH.  */
@@ -1426,18 +1504,14 @@ nios_cgen_rebuild_tables (cd)
    CGEN_CPU_OPEN_END:     terminates arguments
 
    ??? Simultaneous multiple isas might not make sense, but it's not (yet)
-   precluded.
-
-   ??? We only support ISO C stdargs here, not K&R.
-   Laziness, plus experiment to see if anything requires K&R - eventually
-   K&R will no longer be supported - e.g. GDB is currently trying this.  */
+   precluded.  */
 
 CGEN_CPU_DESC
 nios_cgen_cpu_open (enum cgen_cpu_open_arg arg_type, ...)
 {
   CGEN_CPU_TABLE *cd = (CGEN_CPU_TABLE *) xmalloc (sizeof (CGEN_CPU_TABLE));
   static int init_p;
-  unsigned int isas = 0;  /* 0 = "unspecified" */
+  CGEN_BITSET *isas = 0;  /* 0 = "unspecified" */
   unsigned int machs = 0; /* 0 = "unspecified" */
   enum cgen_endian endian = CGEN_ENDIAN_UNKNOWN;
   va_list ap;
@@ -1456,7 +1530,7 @@ nios_cgen_cpu_open (enum cgen_cpu_open_arg arg_type, ...)
       switch (arg_type)
 	{
 	case CGEN_CPU_OPEN_ISAS :
-	  isas = va_arg (ap, unsigned int);
+	  isas = va_arg (ap, CGEN_BITSET *);
 	  break;
 	case CGEN_CPU_OPEN_MACHS :
 	  machs = va_arg (ap, unsigned int);
@@ -1467,37 +1541,40 @@ nios_cgen_cpu_open (enum cgen_cpu_open_arg arg_type, ...)
 	    const CGEN_MACH *mach =
 	      lookup_mach_via_bfd_name (nios_cgen_mach_table, name);
 
-	    machs |= mach->num << 1;
+	    if (mach != NULL)
+	      machs |= 1 << mach->num;
 	    break;
 	  }
 	case CGEN_CPU_OPEN_ENDIAN :
 	  endian = va_arg (ap, enum cgen_endian);
 	  break;
 	default :
-	  fprintf (stderr, "nios_cgen_cpu_open: unsupported argument `%d'\n",
-		   arg_type);
+	  opcodes_error_handler
+	    (/* xgettext:c-format */
+	     _("internal error: nios_cgen_cpu_open: "
+	       "unsupported argument `%d'"),
+	     arg_type);
 	  abort (); /* ??? return NULL? */
 	}
       arg_type = va_arg (ap, enum cgen_cpu_open_arg);
     }
   va_end (ap);
 
-  /* mach unspecified means "all" */
+  /* Mach unspecified means "all".  */
   if (machs == 0)
     machs = (1 << MAX_MACHS) - 1;
-  /* base mach is always selected */
+  /* Base mach is always selected.  */
   machs |= 1;
-  /* isa unspecified means "all" */
-  if (isas == 0)
-    isas = (1 << MAX_ISAS) - 1;
   if (endian == CGEN_ENDIAN_UNKNOWN)
     {
       /* ??? If target has only one, could have a default.  */
-      fprintf (stderr, "nios_cgen_cpu_open: no endianness specified\n");
+      opcodes_error_handler
+	(/* xgettext:c-format */
+	 _("internal error: nios_cgen_cpu_open: no endianness specified"));
       abort ();
     }
 
-  cd->isas = isas;
+  cd->isas = cgen_bitset_copy (isas);
   cd->machs = machs;
   cd->endian = endian;
   /* FIXME: for the sparc case we can determine insn-endianness statically.
@@ -1512,7 +1589,7 @@ nios_cgen_cpu_open (enum cgen_cpu_open_arg arg_type, ...)
 
   /* Default to not allowing signed overflow.  */
   cd->signed_overflow_ok_p = 0;
-  
+
   return (CGEN_CPU_DESC) cd;
 }
 
@@ -1520,9 +1597,7 @@ nios_cgen_cpu_open (enum cgen_cpu_open_arg arg_type, ...)
    MACH_NAME is the bfd name of the mach.  */
 
 CGEN_CPU_DESC
-nios_cgen_cpu_open_1 (mach_name, endian)
-     const char *mach_name;
-     enum cgen_endian endian;
+nios_cgen_cpu_open_1 (const char *mach_name, enum cgen_endian endian)
 {
   return nios_cgen_cpu_open (CGEN_CPU_OPEN_BFDMACH, mach_name,
 			       CGEN_CPU_OPEN_ENDIAN, endian,
@@ -1535,13 +1610,39 @@ nios_cgen_cpu_open_1 (mach_name, endian)
    place as some simulator ports use this but they don't use libopcodes.  */
 
 void
-nios_cgen_cpu_close (cd)
-     CGEN_CPU_DESC cd;
+nios_cgen_cpu_close (CGEN_CPU_DESC cd)
 {
+  unsigned int i;
+  const CGEN_INSN *insns;
+
+  if (cd->macro_insn_table.init_entries)
+    {
+      insns = cd->macro_insn_table.init_entries;
+      for (i = 0; i < cd->macro_insn_table.num_init_entries; ++i, ++insns)
+	if (CGEN_INSN_RX ((insns)))
+	  regfree (CGEN_INSN_RX (insns));
+    }
+
+  if (cd->insn_table.init_entries)
+    {
+      insns = cd->insn_table.init_entries;
+      for (i = 0; i < cd->insn_table.num_init_entries; ++i, ++insns)
+	if (CGEN_INSN_RX (insns))
+	  regfree (CGEN_INSN_RX (insns));
+    }
+
+  if (cd->macro_insn_table.init_entries)
+    free ((CGEN_INSN *) cd->macro_insn_table.init_entries);
+
   if (cd->insn_table.init_entries)
     free ((CGEN_INSN *) cd->insn_table.init_entries);
+
   if (cd->hw_table.entries)
     free ((CGEN_HW_ENTRY *) cd->hw_table.entries);
+
+  if (cd->operand_table.entries)
+    free ((CGEN_HW_ENTRY *) cd->operand_table.entries);
+
   free (cd);
 }
 

--- a/libr/asm/arch/nios/gnu/nios-desc.c
+++ b/libr/asm/arch/nios/gnu/nios-desc.c
@@ -1,0 +1,1546 @@
+/* CPU data for nios.
+
+THIS FILE IS MACHINE GENERATED WITH CGEN.
+
+Copyright (C) 1996, 1997, 1998, 1999, 2001 Free Software Foundation, Inc.
+
+This file is part of the GNU Binutils and/or GDB, the GNU debugger.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#include "sysdep.h"
+#include <ctype.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include "ansidecl.h"
+#include "bfd.h"
+#include "symcat.h"
+#include "nios-desc.h"
+#include "nios-opc.h"
+#include "opintl.h"
+
+/* Attributes.  */
+
+static const CGEN_ATTR_ENTRY bool_attr[] =
+{
+  { "#f", 0 },
+  { "#t", 1 },
+  { 0, 0 }
+};
+
+static const CGEN_ATTR_ENTRY MACH_attr[] =
+{
+  { "base", MACH_BASE },
+  { "nios16", MACH_NIOS16 },
+  { "nios32", MACH_NIOS32 },
+  { "max", MACH_MAX },
+  { 0, 0 }
+};
+
+static const CGEN_ATTR_ENTRY ISA_attr[] =
+{
+  { "nios", ISA_NIOS },
+  { "max", ISA_MAX },
+  { 0, 0 }
+};
+
+const CGEN_ATTR_TABLE nios_cgen_ifield_attr_table[] =
+{
+  { "MACH", & MACH_attr[0] },
+  { "VIRTUAL", &bool_attr[0], &bool_attr[0] },
+  { "PCREL-ADDR", &bool_attr[0], &bool_attr[0] },
+  { "ABS-ADDR", &bool_attr[0], &bool_attr[0] },
+  { "RESERVED", &bool_attr[0], &bool_attr[0] },
+  { "SIGN-OPT", &bool_attr[0], &bool_attr[0] },
+  { "SIGNED", &bool_attr[0], &bool_attr[0] },
+  { 0, 0, 0 }
+};
+
+const CGEN_ATTR_TABLE nios_cgen_hardware_attr_table[] =
+{
+  { "MACH", & MACH_attr[0] },
+  { "VIRTUAL", &bool_attr[0], &bool_attr[0] },
+  { "CACHE-ADDR", &bool_attr[0], &bool_attr[0] },
+  { "PC", &bool_attr[0], &bool_attr[0] },
+  { "PROFILE", &bool_attr[0], &bool_attr[0] },
+  { 0, 0, 0 }
+};
+
+const CGEN_ATTR_TABLE nios_cgen_operand_attr_table[] =
+{
+  { "MACH", & MACH_attr[0] },
+  { "VIRTUAL", &bool_attr[0], &bool_attr[0] },
+  { "PCREL-ADDR", &bool_attr[0], &bool_attr[0] },
+  { "ABS-ADDR", &bool_attr[0], &bool_attr[0] },
+  { "SIGN-OPT", &bool_attr[0], &bool_attr[0] },
+  { "SIGNED", &bool_attr[0], &bool_attr[0] },
+  { "NEGATIVE", &bool_attr[0], &bool_attr[0] },
+  { "RELAX", &bool_attr[0], &bool_attr[0] },
+  { "SEM-ONLY", &bool_attr[0], &bool_attr[0] },
+  { "HASH-PREFIX", &bool_attr[0], &bool_attr[0] },
+  { 0, 0, 0 }
+};
+
+const CGEN_ATTR_TABLE nios_cgen_insn_attr_table[] =
+{
+  { "MACH", & MACH_attr[0] },
+  { "ALIAS", &bool_attr[0], &bool_attr[0] },
+  { "VIRTUAL", &bool_attr[0], &bool_attr[0] },
+  { "UNCOND-CTI", &bool_attr[0], &bool_attr[0] },
+  { "COND-CTI", &bool_attr[0], &bool_attr[0] },
+  { "SKIP-CTI", &bool_attr[0], &bool_attr[0] },
+  { "DELAY-SLOT", &bool_attr[0], &bool_attr[0] },
+  { "RELAXABLE", &bool_attr[0], &bool_attr[0] },
+  { "RELAX", &bool_attr[0], &bool_attr[0] },
+  { "NO-DIS", &bool_attr[0], &bool_attr[0] },
+  { "PBB", &bool_attr[0], &bool_attr[0] },
+  { "PREFIX", &bool_attr[0], &bool_attr[0] },
+  { "PREFIXED-INSN", &bool_attr[0], &bool_attr[0] },
+  { "SKIP-INSN", &bool_attr[0], &bool_attr[0] },
+  { "DUAL-MODE", &bool_attr[0], &bool_attr[0] },
+  { 0, 0, 0 }
+};
+
+/* Instruction set variants.  */
+
+static const CGEN_ISA nios_cgen_isa_table[] = {
+  { "nios", 16, 16, 16, 16,  },
+  { 0 }
+};
+
+/* Machine variants.  */
+
+static const CGEN_MACH nios_cgen_mach_table[] = {
+  { "nios16", "nios16", MACH_NIOS16 },
+  { "nios32", "nios32", MACH_NIOS32 },
+  { 0 }
+};
+
+static CGEN_KEYWORD_ENTRY nios_cgen_opval_ctl_names_entries[] =
+{
+  { "%ctl0", 0 },
+  { "%ctl1", 1 },
+  { "%ctl2", 2 },
+  { "%ctl3", 3 },
+  { "%ctl4", 4 },
+  { "%ctl5", 5 },
+  { "%status", 0 },
+  { "%istatus", 1 },
+  { "%wvalid", 2 },
+  { "%cd_bank", 3 },
+  { "%st_bank", 4 },
+  { "%ld_bank", 5 }
+};
+
+CGEN_KEYWORD nios_cgen_opval_ctl_names =
+{
+  & nios_cgen_opval_ctl_names_entries[0],
+  12
+};
+
+static CGEN_KEYWORD_ENTRY nios_cgen_opval_gr_names_entries[] =
+{
+  { "%sp", 14 },
+  { "%fp", 30 },
+  { "%g0", 0 },
+  { "%g1", 1 },
+  { "%g2", 2 },
+  { "%g3", 3 },
+  { "%g4", 4 },
+  { "%g5", 5 },
+  { "%g6", 6 },
+  { "%g7", 7 },
+  { "%r0", 0 },
+  { "%r1", 1 },
+  { "%r2", 2 },
+  { "%r3", 3 },
+  { "%r4", 4 },
+  { "%r5", 5 },
+  { "%r6", 6 },
+  { "%r7", 7 },
+  { "%o0", 8 },
+  { "%o1", 9 },
+  { "%o2", 10 },
+  { "%o3", 11 },
+  { "%o4", 12 },
+  { "%o5", 13 },
+  { "%o6", 14 },
+  { "%o7", 15 },
+  { "%r8", 8 },
+  { "%r9", 9 },
+  { "%r10", 10 },
+  { "%r11", 11 },
+  { "%r12", 12 },
+  { "%r13", 13 },
+  { "%r14", 14 },
+  { "%r15", 15 },
+  { "%l0", 16 },
+  { "%l1", 17 },
+  { "%l2", 18 },
+  { "%l3", 19 },
+  { "%l4", 20 },
+  { "%l5", 21 },
+  { "%l6", 22 },
+  { "%l7", 23 },
+  { "%r16", 16 },
+  { "%r17", 17 },
+  { "%r18", 18 },
+  { "%r19", 19 },
+  { "%r20", 20 },
+  { "%r21", 21 },
+  { "%r22", 22 },
+  { "%r23", 23 },
+  { "%i0", 24 },
+  { "%i1", 25 },
+  { "%i2", 26 },
+  { "%i3", 27 },
+  { "%i4", 28 },
+  { "%i5", 29 },
+  { "%i6", 30 },
+  { "%i7", 31 },
+  { "%r24", 24 },
+  { "%r25", 25 },
+  { "%r26", 26 },
+  { "%r27", 27 },
+  { "%r28", 28 },
+  { "%r29", 29 },
+  { "%r30", 30 },
+  { "%r31", 31 }
+};
+
+CGEN_KEYWORD nios_cgen_opval_gr_names =
+{
+  & nios_cgen_opval_gr_names_entries[0],
+  66
+};
+
+static CGEN_KEYWORD_ENTRY nios_cgen_opval_gr0_name_entries[] =
+{
+  { "%r0", 0 }
+};
+
+CGEN_KEYWORD nios_cgen_opval_gr0_name =
+{
+  & nios_cgen_opval_gr0_name_entries[0],
+  1
+};
+
+static CGEN_KEYWORD_ENTRY nios_cgen_opval_bp_names_entries[] =
+{
+  { "%l0", 0 },
+  { "%l1", 1 },
+  { "%l2", 2 },
+  { "%l3", 3 },
+  { "%r16", 0 },
+  { "%r17", 1 },
+  { "%r18", 2 },
+  { "%r19", 3 }
+};
+
+CGEN_KEYWORD nios_cgen_opval_bp_names =
+{
+  & nios_cgen_opval_bp_names_entries[0],
+  8
+};
+
+static CGEN_KEYWORD_ENTRY nios_cgen_opval_h_m16_gr0_entries[] =
+{
+  { "%r0", 0 }
+};
+
+CGEN_KEYWORD nios_cgen_opval_h_m16_gr0 =
+{
+  & nios_cgen_opval_h_m16_gr0_entries[0],
+  1
+};
+
+static CGEN_KEYWORD_ENTRY nios_cgen_opval_h_m16_sp_entries[] =
+{
+  { "%sp", 0 }
+};
+
+CGEN_KEYWORD nios_cgen_opval_h_m16_sp =
+{
+  & nios_cgen_opval_h_m16_sp_entries[0],
+  1
+};
+
+static CGEN_KEYWORD_ENTRY nios_cgen_opval_h_m32_sp_entries[] =
+{
+  { "%sp", 0 }
+};
+
+CGEN_KEYWORD nios_cgen_opval_h_m32_sp =
+{
+  & nios_cgen_opval_h_m32_sp_entries[0],
+  1
+};
+
+
+
+/* The hardware table.  */
+
+#define A(a) (1 << CONCAT2 (CGEN_HW_,a))
+
+const CGEN_HW_ENTRY nios_cgen_hw_table[] =
+{
+  { "h-memory", HW_H_MEMORY, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
+  { "h-sint", HW_H_SINT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
+  { "h-uint", HW_H_UINT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
+  { "h-addr", HW_H_ADDR, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
+  { "h-iaddr", HW_H_IADDR, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
+  { "h-pc", HW_H_PC, CGEN_ASM_NONE, 0, { 0|A(PROFILE)|A(PC), { (1<<MACH_BASE) } } },
+  { "h-cwp", HW_H_CWP, CGEN_ASM_NONE, 0, { 0|A(PROFILE), { (1<<MACH_BASE) } } },
+  { "h-old-cwp", HW_H_OLD_CWP, CGEN_ASM_NONE, 0, { 0|A(PROFILE), { (1<<MACH_BASE) } } },
+  { "h-ipri", HW_H_IPRI, CGEN_ASM_NONE, 0, { 0|A(CACHE_ADDR)|A(PROFILE), { (1<<MACH_BASE) } } },
+  { "h-zero", HW_H_ZERO, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
+  { "h-tebit", HW_H_TEBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
+  { "h-nbit", HW_H_NBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
+  { "h-zbit", HW_H_ZBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
+  { "h-vbit", HW_H_VBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
+  { "h-cbit", HW_H_CBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
+  { "h-pbit", HW_H_PBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
+  { "h-sbit", HW_H_SBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
+  { "h-wbit", HW_H_WBIT, CGEN_ASM_NONE, 0, { 0, { (1<<MACH_BASE) } } },
+  { "h-status", HW_H_STATUS, CGEN_ASM_NONE, 0, { 0|A(PROFILE), { (1<<MACH_BASE) } } },
+  { "h-k", HW_H_K, CGEN_ASM_NONE, 0, { 0|A(CACHE_ADDR)|A(PROFILE), { (1<<MACH_BASE) } } },
+  { "h-m16-gr", HW_H_M16_GR, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS16) } } },
+  { "h-m16-gr0", HW_H_M16_GR0, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_h_m16_gr0, { 0|A(VIRTUAL), { (1<<MACH_NIOS16) } } },
+  { "h-m16-bp", HW_H_M16_BP, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_bp_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS16) } } },
+  { "h-m16-rz", HW_H_M16_RZ, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS16) } } },
+  { "h-m16-sp", HW_H_M16_SP, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_h_m16_sp, { 0|A(VIRTUAL), { (1<<MACH_NIOS16) } } },
+  { "h-m16-ctl", HW_H_M16_CTL, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_ctl_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS16) } } },
+  { "h-m32-gr", HW_H_M32_GR, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS32) } } },
+  { "h-m32-gr0", HW_H_M32_GR0, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr0_name, { 0|A(VIRTUAL), { (1<<MACH_NIOS32) } } },
+  { "h-m32-bp", HW_H_M32_BP, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_bp_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS32) } } },
+  { "h-m32-rz", HW_H_M32_RZ, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_gr_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS32) } } },
+  { "h-m32-sp", HW_H_M32_SP, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_h_m32_sp, { 0|A(VIRTUAL), { (1<<MACH_NIOS32) } } },
+  { "h-m32-ctl", HW_H_M32_CTL, CGEN_ASM_KEYWORD, (PTR) & nios_cgen_opval_ctl_names, { 0|A(VIRTUAL), { (1<<MACH_NIOS32) } } },
+  { 0 }
+};
+
+#undef A
+
+/* The instruction field table.  */
+
+#define A(a) (1 << CONCAT2 (CGEN_IFLD_,a))
+
+const CGEN_IFLD nios_cgen_ifld_table[] =
+{
+  { NIOS_F_NIL, "f-nil", 0, 0, 0, 0, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_ANYOF, "f-anyof", 0, 0, 0, 0, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_OP6, "f-op6", 0, 16, 15, 6, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_OP3, "f-op3", 0, 16, 15, 3, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_OP4, "f-op4", 0, 16, 15, 4, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_OP5, "f-op5", 0, 16, 15, 5, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_OP5_HI, "f-op5-hi", 16, 16, 15, 5, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_OP8, "f-op8", 0, 16, 15, 8, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_OP9, "f-op9", 0, 16, 15, 9, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_OP11, "f-op11", 0, 16, 15, 11, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_RA, "f-Ra", 0, 16, 4, 5, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_RB, "f-Rb", 0, 16, 9, 5, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_RBI5, "f-Rbi5", 0, 16, 9, 5, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_RZ, "f-Rz", 0, 16, 1, 2, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_RP, "f-Rp", 0, 16, 11, 2, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_CTLC, "f-CTLc", 0, 16, 4, 3, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_I2, "f-i2", 0, 16, 6, 2, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_I4W, "f-i4w", 0, 16, 3, 4, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_X1, "f-x1", 0, 16, 4, 1, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_O1, "f-o1", 0, 16, 5, 1, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_O2, "f-o2", 0, 16, 7, 2, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_I5, "f-i5", 0, 16, 9, 5, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_I6V, "f-i6v", 0, 16, 5, 6, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_I8, "f-i8", 0, 16, 12, 8, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_I8V, "f-i8v", 0, 16, 7, 8, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_I9, "f-i9", 0, 16, 9, 9, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_I10, "f-i10", 0, 16, 9, 10, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_I11, "f-i11", 0, 16, 10, 11, { 0, { (1<<MACH_BASE) } }  },
+  { NIOS_F_I6_REL_H, "f-i6-rel-h", 0, 16, 10, 6, { 0|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
+  { NIOS_F_I6_REL_W, "f-i6-rel-w", 0, 16, 10, 6, { 0|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
+  { NIOS_F_BSRR_I6_REL, "f-bsrr-i6-rel", 0, 16, 10, 6, { 0|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
+  { NIOS_F_I8V_REL_H, "f-i8v-rel-h", 0, 16, 7, 8, { 0|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
+  { NIOS_F_I8V_REL_W, "f-i8v-rel-w", 0, 16, 7, 8, { 0|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
+  { NIOS_F_I11_REL, "f-i11-rel", 0, 16, 10, 11, { 0|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
+  { NIOS_F_I1, "f-i1", 0, 16, 6, 2, { 0, { (1<<MACH_BASE) } }  },
+  { 0 }
+};
+
+#undef A
+
+/* The operand table.  */
+
+#define A(a) (1 << CONCAT2 (CGEN_OPERAND_,a))
+#define OPERAND(op) CONCAT2 (NIOS_OPERAND_,op)
+
+const CGEN_OPERAND nios_cgen_operand_table[] =
+{
+/* pc: program counter */
+  { "pc", NIOS_OPERAND_PC, HW_H_PC, 0, 0,
+    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+/* K: K register */
+  { "K", NIOS_OPERAND_K, HW_H_K, 0, 0,
+    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+/* CTLc: control register index */
+  { "CTLc", NIOS_OPERAND_CTLC, HW_H_UINT, 4, 3,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* xRa: Ra ignored */
+  { "xRa", NIOS_OPERAND_XRA, HW_H_UINT, 4, 5,
+    { 0, { (1<<MACH_BASE) } }  },
+/* x1: 1 bit ignored */
+  { "x1", NIOS_OPERAND_X1, HW_H_UINT, 4, 1,
+    { 0, { (1<<MACH_BASE) } }  },
+/* o1: zero-bit */
+  { "o1", NIOS_OPERAND_O1, HW_H_ZERO, 5, 1,
+    { 0, { (1<<MACH_BASE) } }  },
+/* o2: 2 zero bits */
+  { "o2", NIOS_OPERAND_O2, HW_H_ZERO, 7, 2,
+    { 0, { (1<<MACH_BASE) } }  },
+/* i1: 1 bit unsigned immediate */
+  { "i1", NIOS_OPERAND_I1, HW_H_UINT, 6, 2,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* i2: 2 bit unsigned immediate */
+  { "i2", NIOS_OPERAND_I2, HW_H_UINT, 6, 2,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* si5: 5 bit signed immediate */
+  { "si5", NIOS_OPERAND_SI5, HW_H_SINT, 9, 5,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* i8: 8 bit unsigned immediate */
+  { "i8", NIOS_OPERAND_I8, HW_H_UINT, 12, 8,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* i8v: 8 bit unsigned immediate v */
+  { "i8v", NIOS_OPERAND_I8V, HW_H_UINT, 7, 8,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* i6v: 6 bit unsigned immediate v */
+  { "i6v", NIOS_OPERAND_I6V, HW_H_UINT, 5, 6,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* si11: 11 bit signed immediate */
+  { "si11", NIOS_OPERAND_SI11, HW_H_SINT, 10, 11,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* rel11: 11 bit relative address */
+  { "rel11", NIOS_OPERAND_REL11, HW_H_IADDR, 10, 11,
+    { 0|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
+/* bsrr_rel6: dummy 6 bit relative address */
+  { "bsrr_rel6", NIOS_OPERAND_BSRR_REL6, HW_H_IADDR, 10, 6,
+    { 0|A(RELAX)|A(PCREL_ADDR), { (1<<MACH_BASE) } }  },
+/* nbit: negative    bit */
+  { "nbit", NIOS_OPERAND_NBIT, HW_H_NBIT, 0, 0,
+    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+/* vbit: overflow    bit */
+  { "vbit", NIOS_OPERAND_VBIT, HW_H_VBIT, 0, 0,
+    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+/* zbit: zero        bit */
+  { "zbit", NIOS_OPERAND_ZBIT, HW_H_ZBIT, 0, 0,
+    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+/* cbit: carry       bit */
+  { "cbit", NIOS_OPERAND_CBIT, HW_H_CBIT, 0, 0,
+    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+/* tebit: trap-enable bit */
+  { "tebit", NIOS_OPERAND_TEBIT, HW_H_TEBIT, 0, 0,
+    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+/* pbit: prefix      bit */
+  { "pbit", NIOS_OPERAND_PBIT, HW_H_PBIT, 0, 0,
+    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+/* sbit: skip        bit */
+  { "sbit", NIOS_OPERAND_SBIT, HW_H_SBIT, 0, 0,
+    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+/* wbit: window chg  bit */
+  { "wbit", NIOS_OPERAND_WBIT, HW_H_WBIT, 0, 0,
+    { 0|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+/* i4w: 4 bit condition code index */
+  { "i4w", NIOS_OPERAND_I4W, HW_H_UINT, 3, 4,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* i4wn: 4 bit condition code index reversed */
+  { "i4wn", NIOS_OPERAND_I4WN, HW_H_UINT, 3, 4,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* i5: 5 bit unsigned immediate */
+  { "i5", NIOS_OPERAND_I5, HW_H_UINT, 9, 5,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* save_i8v: 8 bit unsigned immediate for save insn */
+  { "save_i8v", NIOS_OPERAND_SAVE_I8V, HW_H_UINT, 7, 8,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* i11: 11 bit unsigned immediate */
+  { "i11", NIOS_OPERAND_I11, HW_H_UINT, 10, 11,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* i10: 10 bit unsigned immediate */
+  { "i10", NIOS_OPERAND_I10, HW_H_UINT, 9, 10,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* i9: 9 bit unsigned immediate */
+  { "i9", NIOS_OPERAND_I9, HW_H_UINT, 9, 9,
+    { 0|A(HASH_PREFIX), { (1<<MACH_BASE) } }  },
+/* i16: 16 bit unsigned immediate */
+  { "i16", NIOS_OPERAND_I16, HW_H_UINT, 0, 0,
+    { 0|A(HASH_PREFIX)|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+/* i32: 32 bit unsigned immediate */
+  { "i32", NIOS_OPERAND_I32, HW_H_UINT, 0, 0,
+    { 0|A(HASH_PREFIX)|A(SEM_ONLY), { (1<<MACH_BASE) } }  },
+/* Rbi5: 5 bit register or unsigned immediate */
+  { "Rbi5", NIOS_OPERAND_RBI5, HW_H_UINT, 9, 5,
+    { 0, { (1<<MACH_BASE) } }  },
+/* m16_Ra: source register a */
+  { "m16_Ra", NIOS_OPERAND_M16_RA, HW_H_M16_GR, 4, 5,
+    { 0, { (1<<MACH_NIOS16) } }  },
+/* m16_Rb: source register b */
+  { "m16_Rb", NIOS_OPERAND_M16_RB, HW_H_M16_GR, 9, 5,
+    { 0, { (1<<MACH_NIOS16) } }  },
+/* m16_R0: source register 0 */
+  { "m16_R0", NIOS_OPERAND_M16_R0, HW_H_M16_GR0, 0, 0,
+    { 0, { (1<<MACH_NIOS16) } }  },
+/* m16_sp: stack pointer */
+  { "m16_sp", NIOS_OPERAND_M16_SP, HW_H_M16_SP, 0, 0,
+    { 0, { (1<<MACH_NIOS16) } }  },
+/* m16_Rp: base pointer register */
+  { "m16_Rp", NIOS_OPERAND_M16_RP, HW_H_M16_BP, 11, 2,
+    { 0, { (1<<MACH_NIOS16) } }  },
+/* m16_Rz: ctl target register */
+  { "m16_Rz", NIOS_OPERAND_M16_RZ, HW_H_M16_RZ, 1, 2,
+    { 0, { (1<<MACH_NIOS16) } }  },
+/* m16_i6: 6-bit half-word pc rel */
+  { "m16_i6", NIOS_OPERAND_M16_I6, HW_H_IADDR, 10, 6,
+    { 0|A(PCREL_ADDR), { (1<<MACH_NIOS16) } }  },
+/* m16_i8v: 8-bit half-word pc rel */
+  { "m16_i8v", NIOS_OPERAND_M16_I8V, HW_H_IADDR, 7, 8,
+    { 0|A(PCREL_ADDR), { (1<<MACH_NIOS16) } }  },
+/* m32_Ra: source register a */
+  { "m32_Ra", NIOS_OPERAND_M32_RA, HW_H_M32_GR, 4, 5,
+    { 0, { (1<<MACH_NIOS32) } }  },
+/* m32_Rb: source register b */
+  { "m32_Rb", NIOS_OPERAND_M32_RB, HW_H_M32_GR, 9, 5,
+    { 0, { (1<<MACH_NIOS32) } }  },
+/* m32_R0: source register 0 */
+  { "m32_R0", NIOS_OPERAND_M32_R0, HW_H_M32_GR0, 0, 0,
+    { 0, { (1<<MACH_NIOS32) } }  },
+/* m32_sp: stack pointer */
+  { "m32_sp", NIOS_OPERAND_M32_SP, HW_H_M32_SP, 0, 0,
+    { 0, { (1<<MACH_NIOS32) } }  },
+/* m32_Rp: base pointer register */
+  { "m32_Rp", NIOS_OPERAND_M32_RP, HW_H_M32_BP, 11, 2,
+    { 0, { (1<<MACH_NIOS32) } }  },
+/* m32_Rz: ctl target register */
+  { "m32_Rz", NIOS_OPERAND_M32_RZ, HW_H_M32_RZ, 1, 2,
+    { 0, { (1<<MACH_NIOS32) } }  },
+/* m32_i6: 6-bit word pc rel */
+  { "m32_i6", NIOS_OPERAND_M32_I6, HW_H_IADDR, 10, 6,
+    { 0|A(PCREL_ADDR), { (1<<MACH_NIOS32) } }  },
+/* m32_i8v: 8-bit word pc rel */
+  { "m32_i8v", NIOS_OPERAND_M32_I8V, HW_H_IADDR, 7, 8,
+    { 0|A(PCREL_ADDR), { (1<<MACH_NIOS32) } }  },
+  { 0 }
+};
+
+#undef A
+
+#define A(a) (1 << CONCAT2 (CGEN_INSN_,a))
+#define OP(field) CGEN_SYNTAX_MAKE_FIELD (OPERAND (field))
+
+/* The instruction table.  */
+
+static const CGEN_IBASE nios_cgen_insn_table[MAX_INSNS] =
+{
+  /* Special null first entry.
+     A `num' value of zero is thus invalid.
+     Also, the special `invalid' insn resides here.  */
+  { 0, 0, 0 },
+/* ext8s $m16_Ra,$i1 */
+  {
+    NIOS_INSN_EXT8S16, "ext8s16", "ext8s", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* st8s [$m16_Ra],$m16_R0,$i1 */
+  {
+    NIOS_INSN_ST8S16, "st8s16", "st8s", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+  },
+/* sts8s [$m16_sp,$i10],$m16_R0 */
+  {
+    NIOS_INSN_STS8S16, "sts8s16", "sts8s", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* st8d [$m16_Ra],$m16_R0 */
+  {
+    NIOS_INSN_ST8D16, "st8d16", "st8d", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* wrctl $m16_Ra */
+  {
+    NIOS_INSN_WRCTL16, "wrctl16", "wrctl", 16,
+    { 0|A(DELAY_SLOT)|A(COND_CTI), { (1<<MACH_NIOS16) } }
+  },
+/* addc $m16_Ra,$m16_Rb */
+  {
+    NIOS_INSN_ADDC16, "addc16", "addc", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* subc $m16_Ra,$m16_Rb */
+  {
+    NIOS_INSN_SUBC16, "subc16", "subc", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* add $m16_Ra,$m16_Rb */
+  {
+    NIOS_INSN_ADD16, "add16", "add", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* sub $m16_Ra,$m16_Rb */
+  {
+    NIOS_INSN_SUB16, "sub16", "sub", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* addi $m16_Ra,$i5 */
+  {
+    NIOS_INSN_ADDI16, "addi16", "addi", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+  },
+/* subi $m16_Ra,$i5 */
+  {
+    NIOS_INSN_SUBI16, "subi16", "subi", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+  },
+/* or $m16_Ra,$Rbi5 */
+  {
+    NIOS_INSN_OR16, "or16", "or", 16,
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+  },
+/* xor $m16_Ra,$Rbi5 */
+  {
+    NIOS_INSN_XOR16, "xor16", "xor", 16,
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+  },
+/* and $m16_Ra,$Rbi5 */
+  {
+    NIOS_INSN_AND16, "and16", "and", 16,
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+  },
+/* andn $m16_Ra,$Rbi5 */
+  {
+    NIOS_INSN_ANDN16, "andn16", "andn", 16,
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+  },
+/* lsl $m16_Ra,$m16_Rb */
+  {
+    NIOS_INSN_LSL16, "lsl16", "lsl", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* lsr $m16_Ra,$m16_Rb */
+  {
+    NIOS_INSN_LSR16, "lsr16", "lsr", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* asr $m16_Ra,$m16_Rb */
+  {
+    NIOS_INSN_ASR16, "asr16", "asr", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* lsli $m16_Ra,$i5 */
+  {
+    NIOS_INSN_LSLI16, "lsli16", "lsli", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* lsri $m16_Ra,$i5 */
+  {
+    NIOS_INSN_LSRI16, "lsri16", "lsri", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* asri $m16_Ra,$i5 */
+  {
+    NIOS_INSN_ASRI16, "asri16", "asri", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* not $m16_Ra */
+  {
+    NIOS_INSN_NOT16, "not16", "not", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* neg $m16_Ra */
+  {
+    NIOS_INSN_NEG16, "neg16", "neg", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* abs $m16_Ra */
+  {
+    NIOS_INSN_ABS16, "abs16", "abs", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* mov $m16_Ra,$m16_Rb */
+  {
+    NIOS_INSN_MOV16, "mov16", "mov", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* movi $m16_Ra,$i5 */
+  {
+    NIOS_INSN_MOVI16, "movi16", "movi", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+  },
+/* bgen $m16_Ra,$i5 */
+  {
+    NIOS_INSN_BGEN16, "bgen16", "bgen", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* cmp $m16_Ra,$m16_Rb */
+  {
+    NIOS_INSN_CMP16, "cmp16", "cmp", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* cmpi $m16_Ra,$i5 */
+  {
+    NIOS_INSN_CMPI16, "cmpi16", "cmpi", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+  },
+/* ext8d $m16_Ra,$m16_Rb */
+  {
+    NIOS_INSN_EXT8D16, "ext8d16", "ext8d", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* sext8 $m16_Ra */
+  {
+    NIOS_INSN_SEXT816, "sext816", "sext8", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* fill8 $m16_R0,$m16_Ra */
+  {
+    NIOS_INSN_FILL816, "fill816", "fill8", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* lds $m16_Ra,[$m16_sp,$i8] */
+  {
+    NIOS_INSN_LDS16, "lds16", "lds", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* sts [$m16_sp,$i8],$m16_Ra */
+  {
+    NIOS_INSN_STS16, "sts16", "sts", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* ldp $m16_Ra,[$m16_Rp,$i5] */
+  {
+    NIOS_INSN_LDP16, "ldp16", "ldp", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+  },
+/* stp [$m16_Rp,$i5],$m16_Ra */
+  {
+    NIOS_INSN_STP16, "stp16", "stp", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+  },
+/* ld $m16_Ra,[$m16_Rb] */
+  {
+    NIOS_INSN_LD16, "ld16", "ld", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+  },
+/* st [$m16_Rb],$m16_Ra */
+  {
+    NIOS_INSN_ST16, "st16", "st", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS16) } }
+  },
+/* trap $i6v */
+  {
+    NIOS_INSN_TRAP16, "trap16", "trap", 16,
+    { 0|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+  },
+/* tret $m16_Ra */
+  {
+    NIOS_INSN_TRET16, "tret16", "tret", 16,
+    { 0|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+  },
+/* save $m16_sp,$save_i8v */
+  {
+    NIOS_INSN_SAVE16, "save16", "save", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* restore */
+  {
+    NIOS_INSN_RESTORE16, "restore16", "restore", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* bsr $rel11 */
+  {
+    NIOS_INSN_BSR16, "bsr16", "bsr", 16,
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+  },
+/* bsrr $m16_Ra,$bsrr_rel6 */
+  {
+    NIOS_INSN_BSRR16, "bsrr16", "bsrr", 16,
+    { 0|A(RELAXABLE)|A(NO_DIS)|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+  },
+/* jmp $m16_Ra */
+  {
+    NIOS_INSN_JMP16, "jmp16", "jmp", 16,
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+  },
+/* call $m16_Ra */
+  {
+    NIOS_INSN_CALL16, "call16", "call", 16,
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+  },
+/* jmpc [$m16_i8v] */
+  {
+    NIOS_INSN_JMPC16, "jmpc16", "jmpc", 16,
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+  },
+/* callc [$m16_i8v] */
+  {
+    NIOS_INSN_CALLC16, "callc16", "callc", 16,
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS16) } }
+  },
+/* skp0 $m16_Ra,$i5 */
+  {
+    NIOS_INSN_SKP016, "skp016", "skp0", 16,
+    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS16) } }
+  },
+/* skp1 $m16_Ra,$i5 */
+  {
+    NIOS_INSN_SKP116, "skp116", "skp1", 16,
+    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS16) } }
+  },
+/* skprz $m16_Ra */
+  {
+    NIOS_INSN_SKPRZ16, "skprz16", "skprz", 16,
+    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS16) } }
+  },
+/* skprnz $m16_Ra */
+  {
+    NIOS_INSN_SKPRNZ16, "skprnz16", "skprnz", 16,
+    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS16) } }
+  },
+/* skps $i4w */
+  {
+    NIOS_INSN_SKPS16, "skps16", "skps", 16,
+    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS16) } }
+  },
+/* rrc $m16_Ra */
+  {
+    NIOS_INSN_RRC16, "rrc16", "rrc", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* rlc $m16_Ra */
+  {
+    NIOS_INSN_RLC16, "rlc16", "rlc", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* rdctl $m16_Ra */
+  {
+    NIOS_INSN_RDCTL16, "rdctl16", "rdctl", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* usr0 $m16_Ra */
+  {
+    NIOS_INSN_USR016, "usr016", "usr0", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* usr1 $m16_Ra,$m16_R0 */
+  {
+    NIOS_INSN_USR116, "usr116", "usr1", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* usr2 $m16_Ra,$m16_R0 */
+  {
+    NIOS_INSN_USR216, "usr216", "usr2", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* usr3 $m16_Ra,$m16_R0 */
+  {
+    NIOS_INSN_USR316, "usr316", "usr3", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* usr4 $m16_Ra,$m16_R0 */
+  {
+    NIOS_INSN_USR416, "usr416", "usr4", 16,
+    { 0, { (1<<MACH_NIOS16) } }
+  },
+/* sts8s [$m32_sp,$i10],$m32_R0 */
+  {
+    NIOS_INSN_STS8S32, "sts8s32", "sts8s", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* sts16s [$m32_sp,$i9],$m32_R0 */
+  {
+    NIOS_INSN_STS16S, "sts16s", "sts16s", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* movhi $m32_Ra,$i5 */
+  {
+    NIOS_INSN_MOVHI, "movhi", "movhi", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* ext16d $m32_Ra,$m32_Rb */
+  {
+    NIOS_INSN_EXT16D, "ext16d", "ext16d", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* sext16 $m32_Ra */
+  {
+    NIOS_INSN_SEXT16, "sext16", "sext16", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* st16d [$m32_Ra],$m32_R0 */
+  {
+    NIOS_INSN_ST16D, "st16d", "st16d", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* fill16 $m32_R0,$m32_Ra */
+  {
+    NIOS_INSN_FILL16, "fill16", "fill16", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* ext8s $m32_Ra,$i2 */
+  {
+    NIOS_INSN_EXT8S32, "ext8s32", "ext8s", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* st8s [$m32_Ra],$m32_R0,$i2 */
+  {
+    NIOS_INSN_ST8S32, "st8s32", "st8s", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* ext16s $m32_Ra,$i1 */
+  {
+    NIOS_INSN_EXT16S, "ext16s", "ext16s", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* st16s [$m32_Ra],$m32_R0,$i1 */
+  {
+    NIOS_INSN_ST16S, "st16s", "st16s", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* st8d [$m32_Ra],$m32_R0 */
+  {
+    NIOS_INSN_ST8D32, "st8d32", "st8d", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* wrctl $m32_Ra */
+  {
+    NIOS_INSN_WRCTL32, "wrctl32", "wrctl", 16,
+    { 0|A(DELAY_SLOT)|A(COND_CTI), { (1<<MACH_NIOS32) } }
+  },
+/* add $m32_Ra,$m32_Rb */
+  {
+    NIOS_INSN_ADD32, "add32", "add", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* sub $m32_Ra,$m32_Rb */
+  {
+    NIOS_INSN_SUB32, "sub32", "sub", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* addi $m32_Ra,$i5 */
+  {
+    NIOS_INSN_ADDI32, "addi32", "addi", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* subi $m32_Ra,$i5 */
+  {
+    NIOS_INSN_SUBI32, "subi32", "subi", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* or $m32_Ra,$Rbi5 */
+  {
+    NIOS_INSN_OR32, "or32", "or", 16,
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* xor $m32_Ra,$Rbi5 */
+  {
+    NIOS_INSN_XOR32, "xor32", "xor", 16,
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* and $m32_Ra,$Rbi5 */
+  {
+    NIOS_INSN_AND32, "and32", "and", 16,
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* andn $m32_Ra,$Rbi5 */
+  {
+    NIOS_INSN_ANDN32, "andn32", "andn", 16,
+    { 0|A(DUAL_MODE)|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* lsl $m32_Ra,$m32_Rb */
+  {
+    NIOS_INSN_LSL32, "lsl32", "lsl", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* lsr $m32_Ra,$m32_Rb */
+  {
+    NIOS_INSN_LSR32, "lsr32", "lsr", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* asr $m32_Ra,$m32_Rb */
+  {
+    NIOS_INSN_ASR32, "asr32", "asr", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* lsli $m32_Ra,$i5 */
+  {
+    NIOS_INSN_LSLI32, "lsli32", "lsli", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* lsri $m32_Ra,$i5 */
+  {
+    NIOS_INSN_LSRI32, "lsri32", "lsri", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* asri $m32_Ra,$i5 */
+  {
+    NIOS_INSN_ASRI32, "asri32", "asri", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* not $m32_Ra */
+  {
+    NIOS_INSN_NOT32, "not32", "not", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* neg $m32_Ra */
+  {
+    NIOS_INSN_NEG32, "neg32", "neg", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* abs $m32_Ra */
+  {
+    NIOS_INSN_ABS32, "abs32", "abs", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* mov $m32_Ra,$m32_Rb */
+  {
+    NIOS_INSN_MOV32, "mov32", "mov", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* movi $m32_Ra,$i5 */
+  {
+    NIOS_INSN_MOVI32, "movi32", "movi", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* bgen $m32_Ra,$i5 */
+  {
+    NIOS_INSN_BGEN32, "bgen32", "bgen", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* cmp $m32_Ra,$m32_Rb */
+  {
+    NIOS_INSN_CMP32, "cmp32", "cmp", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* cmpi $m32_Ra,$i5 */
+  {
+    NIOS_INSN_CMPI32, "cmpi32", "cmpi", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* ext8d $m32_Ra,$m32_Rb */
+  {
+    NIOS_INSN_EXT8D32, "ext8d32", "ext8d", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* sext8 $m32_Ra */
+  {
+    NIOS_INSN_SEXT832, "sext832", "sext8", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* fill8 $m32_R0,$m32_Ra */
+  {
+    NIOS_INSN_FILL832, "fill832", "fill8", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* lds $m32_Ra,[$m32_sp,$i8] */
+  {
+    NIOS_INSN_LDS32, "lds32", "lds", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* sts [$m32_sp,$i8],$m32_Ra */
+  {
+    NIOS_INSN_STS32, "sts32", "sts", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* ldp $m32_Ra,[$m32_Rp,$i5] */
+  {
+    NIOS_INSN_LDP32, "ldp32", "ldp", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* stp [$m32_Rp,$i5],$m32_Ra */
+  {
+    NIOS_INSN_STP32, "stp32", "stp", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* ld $m32_Ra,[$m32_Rb] */
+  {
+    NIOS_INSN_LD32, "ld32", "ld", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* st [$m32_Rb],$m32_Ra */
+  {
+    NIOS_INSN_ST32, "st32", "st", 16,
+    { 0|A(PREFIXED_INSN), { (1<<MACH_NIOS32) } }
+  },
+/* trap $i6v */
+  {
+    NIOS_INSN_TRAP32, "trap32", "trap", 16,
+    { 0|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+  },
+/* tret $m32_Ra */
+  {
+    NIOS_INSN_TRET32, "tret32", "tret", 16,
+    { 0|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+  },
+/* save $m32_sp,$save_i8v */
+  {
+    NIOS_INSN_SAVE32, "save32", "save", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* restore */
+  {
+    NIOS_INSN_RESTORE32, "restore32", "restore", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* bsr $rel11 */
+  {
+    NIOS_INSN_BSR32, "bsr32", "bsr", 16,
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+  },
+/* bsrr $m32_Ra,$bsrr_rel6 */
+  {
+    NIOS_INSN_BSRR32, "bsrr32", "bsrr", 16,
+    { 0|A(RELAXABLE)|A(NO_DIS)|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+  },
+/* jmp $m32_Ra */
+  {
+    NIOS_INSN_JMP32, "jmp32", "jmp", 16,
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+  },
+/* call $m32_Ra */
+  {
+    NIOS_INSN_CALL32, "call32", "call", 16,
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+  },
+/* jmpc [$m32_i8v] */
+  {
+    NIOS_INSN_JMPC32, "jmpc32", "jmpc", 16,
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+  },
+/* callc [$m32_i8v] */
+  {
+    NIOS_INSN_CALLC32, "callc32", "callc", 16,
+    { 0|A(DELAY_SLOT)|A(UNCOND_CTI), { (1<<MACH_NIOS32) } }
+  },
+/* skp0 $m32_Ra,$i5 */
+  {
+    NIOS_INSN_SKP032, "skp032", "skp0", 16,
+    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS32) } }
+  },
+/* skp1 $m32_Ra,$i5 */
+  {
+    NIOS_INSN_SKP132, "skp132", "skp1", 16,
+    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS32) } }
+  },
+/* skprz $m32_Ra */
+  {
+    NIOS_INSN_SKPRZ32, "skprz32", "skprz", 16,
+    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS32) } }
+  },
+/* skprnz $m32_Ra */
+  {
+    NIOS_INSN_SKPRNZ32, "skprnz32", "skprnz", 16,
+    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS32) } }
+  },
+/* skps $i4w */
+  {
+    NIOS_INSN_SKPS32, "skps32", "skps", 16,
+    { 0|A(SKIP_INSN)|A(COND_CTI), { (1<<MACH_NIOS32) } }
+  },
+/* rrc $m32_Ra */
+  {
+    NIOS_INSN_RRC32, "rrc32", "rrc", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* rlc $m32_Ra */
+  {
+    NIOS_INSN_RLC32, "rlc32", "rlc", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* rdctl $m32_Ra */
+  {
+    NIOS_INSN_RDCTL32, "rdctl32", "rdctl", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* pfx $i11 */
+  {
+    NIOS_INSN_PFX, "pfx", "pfx", 16,
+    { 0|A(PREFIX), { (1<<MACH_BASE) } }
+  },
+/* br $rel11 */
+  {
+    NIOS_INSN_BR, "br", "br", 16,
+    { 0|A(UNCOND_CTI)|A(DELAY_SLOT), { (1<<MACH_BASE) } }
+  },
+/* swap $m32_Ra */
+  {
+    NIOS_INSN_SWAP32, "swap32", "swap", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* mstep $m32_Ra */
+  {
+    NIOS_INSN_RRC32, "mstep32", "mstep", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* mul $m32_Ra */
+  {
+    NIOS_INSN_RRC32, "mul32", "mul", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* usr0 $m32_Ra,$m32_Rb */
+  {
+    NIOS_INSN_USR032, "usr032", "usr0", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* usr1 [$m32_Ra],$m32_R0 */
+  {
+    NIOS_INSN_USR132, "usr132", "usr1", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* usr2 [$m32_Ra],$m32_R0 */
+  {
+    NIOS_INSN_USR232, "usr232", "usr2", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* usr3 [$m32_Ra],$m32_R0 */
+  {
+    NIOS_INSN_USR332, "usr332", "usr3", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* usr4 [$m32_Ra],$m32_R0 */
+  {
+    NIOS_INSN_USR432, "usr432", "usr4", 16,
+    { 0, { (1<<MACH_NIOS32) } }
+  },
+/* pfxio $i11 */
+  {
+    NIOS_INSN_PFXIO, "pfxio", "pfxio", 16,
+    { 0|A(PREFIX), { (1<<MACH_BASE) } }
+  },
+};
+
+#undef A
+#undef MNEM
+#undef OP
+
+/* Initialize anything needed to be done once, before any cpu_open call.  */
+
+static void
+init_tables ()
+{
+}
+
+/* Subroutine of nios_cgen_cpu_open to look up a mach via its bfd name.  */
+
+static const CGEN_MACH *
+lookup_mach_via_bfd_name (table, name)
+     const CGEN_MACH *table;
+     const char *name;
+{
+  while (table->name)
+    {
+      if (strcmp (name, table->bfd_name) == 0)
+	return table;
+      ++table;
+    }
+  abort ();
+}
+
+/* Subroutine of nios_cgen_cpu_open to build the hardware table.  */
+
+static void
+build_hw_table (cd)
+     CGEN_CPU_TABLE *cd;
+{
+  int i;
+  int machs = cd->machs;
+  const CGEN_HW_ENTRY *init = & nios_cgen_hw_table[0];
+  /* MAX_HW is only an upper bound on the number of selected entries.
+     However each entry is indexed by it's enum so there can be holes in
+     the table.  */
+  const CGEN_HW_ENTRY **selected =
+    (const CGEN_HW_ENTRY **) xmalloc (MAX_HW * sizeof (CGEN_HW_ENTRY *));
+
+  cd->hw_table.init_entries = init;
+  cd->hw_table.entry_size = sizeof (CGEN_HW_ENTRY);
+  memset (selected, 0, MAX_HW * sizeof (CGEN_HW_ENTRY *));
+  /* ??? For now we just use machs to determine which ones we want.  */
+  for (i = 0; init[i].name != NULL; ++i)
+    if (CGEN_HW_ATTR_VALUE (&init[i], CGEN_HW_MACH)
+	& machs)
+      selected[init[i].type] = &init[i];
+  cd->hw_table.entries = selected;
+  cd->hw_table.num_entries = MAX_HW;
+}
+
+/* Subroutine of nios_cgen_cpu_open to build the hardware table.  */
+
+static void
+build_ifield_table (cd)
+     CGEN_CPU_TABLE *cd;
+{
+  cd->ifld_table = & nios_cgen_ifld_table[0];
+}
+
+/* Subroutine of nios_cgen_cpu_open to build the hardware table.  */
+
+static void
+build_operand_table (cd)
+     CGEN_CPU_TABLE *cd;
+{
+  int i;
+  int machs = cd->machs;
+  const CGEN_OPERAND *init = & nios_cgen_operand_table[0];
+  /* MAX_OPERANDS is only an upper bound on the number of selected entries.
+     However each entry is indexed by it's enum so there can be holes in
+     the table.  */
+  const CGEN_OPERAND **selected =
+    (const CGEN_OPERAND **) xmalloc (MAX_OPERANDS * sizeof (CGEN_OPERAND *));
+
+  cd->operand_table.init_entries = init;
+  cd->operand_table.entry_size = sizeof (CGEN_OPERAND);
+  memset (selected, 0, MAX_OPERANDS * sizeof (CGEN_OPERAND *));
+  /* ??? For now we just use mach to determine which ones we want.  */
+  for (i = 0; init[i].name != NULL; ++i)
+    if (CGEN_OPERAND_ATTR_VALUE (&init[i], CGEN_OPERAND_MACH)
+	& machs)
+      selected[init[i].type] = &init[i];
+  cd->operand_table.entries = selected;
+  cd->operand_table.num_entries = MAX_OPERANDS;
+}
+
+/* Subroutine of nios_cgen_cpu_open to build the hardware table.
+   ??? This could leave out insns not supported by the specified mach/isa,
+   but that would cause errors like "foo only supported by bar" to become
+   "unknown insn", so for now we include all insns and require the app to
+   do the checking later.
+   ??? On the other hand, parsing of such insns may require their hardware or
+   operand elements to be in the table [which they mightn't be].  */
+
+static void
+build_insn_table (cd)
+     CGEN_CPU_TABLE *cd;
+{
+  int i;
+  const CGEN_IBASE *ib = & nios_cgen_insn_table[0];
+  CGEN_INSN *insns = (CGEN_INSN *) xmalloc (MAX_INSNS * sizeof (CGEN_INSN));
+
+  memset (insns, 0, MAX_INSNS * sizeof (CGEN_INSN));
+  for (i = 0; i < MAX_INSNS; ++i)
+    insns[i].base = &ib[i];
+  cd->insn_table.init_entries = insns;
+  cd->insn_table.entry_size = sizeof (CGEN_IBASE);
+  cd->insn_table.num_init_entries = MAX_INSNS;
+}
+
+/* Subroutine of nios_cgen_cpu_open to rebuild the tables.  */
+
+static void
+nios_cgen_rebuild_tables (cd)
+     CGEN_CPU_TABLE *cd;
+{
+  int i,n_isas,n_machs;
+  unsigned int isas = cd->isas;
+  unsigned int machs = cd->machs;
+
+  cd->int_insn_p = CGEN_INT_INSN_P;
+
+  /* Data derived from the isa spec.  */
+#define UNSET (CGEN_SIZE_UNKNOWN + 1)
+  cd->default_insn_bitsize = UNSET;
+  cd->base_insn_bitsize = UNSET;
+  cd->min_insn_bitsize = 65535; /* some ridiculously big number */
+  cd->max_insn_bitsize = 0;
+  for (i = 0; i < MAX_ISAS; ++i)
+    if (((1 << i) & isas) != 0)
+      {
+	const CGEN_ISA *isa = & nios_cgen_isa_table[i];
+
+	/* Default insn sizes of all selected isas must be equal or we set
+	   the result to 0, meaning "unknown".  */
+	if (cd->default_insn_bitsize == UNSET)
+	  cd->default_insn_bitsize = isa->default_insn_bitsize;
+	else if (isa->default_insn_bitsize == cd->default_insn_bitsize)
+	  ; /* this is ok */
+	else
+	  cd->default_insn_bitsize = CGEN_SIZE_UNKNOWN;
+
+	/* Base insn sizes of all selected isas must be equal or we set
+	   the result to 0, meaning "unknown".  */
+	if (cd->base_insn_bitsize == UNSET)
+	  cd->base_insn_bitsize = isa->base_insn_bitsize;
+	else if (isa->base_insn_bitsize == cd->base_insn_bitsize)
+	  ; /* this is ok */
+	else
+	  cd->base_insn_bitsize = CGEN_SIZE_UNKNOWN;
+
+	/* Set min,max insn sizes.  */
+	if (isa->min_insn_bitsize < cd->min_insn_bitsize)
+	  cd->min_insn_bitsize = isa->min_insn_bitsize;
+	if (isa->max_insn_bitsize > cd->max_insn_bitsize)
+	  cd->max_insn_bitsize = isa->max_insn_bitsize;
+
+	++n_isas;
+      }
+
+  /* Data derived from the mach spec.  */
+  for (i = 0; i < MAX_MACHS; ++i)
+    if (((1 << i) & machs) != 0)
+      {
+	const CGEN_MACH *mach = & nios_cgen_mach_table[i];
+
+	++n_machs;
+      }
+
+  /* Determine which hw elements are used by MACH.  */
+  build_hw_table (cd);
+
+  /* Build the ifield table.  */
+  build_ifield_table (cd);
+
+  /* Determine which operands are used by MACH/ISA.  */
+  build_operand_table (cd);
+
+  /* Build the instruction table.  */
+  build_insn_table (cd);
+}
+
+/* Initialize a cpu table and return a descriptor.
+   It's much like opening a file, and must be the first function called.
+   The arguments are a set of (type/value) pairs, terminated with
+   CGEN_CPU_OPEN_END.
+
+   Currently supported values:
+   CGEN_CPU_OPEN_ISAS:    bitmap of values in enum isa_attr
+   CGEN_CPU_OPEN_MACHS:   bitmap of values in enum mach_attr
+   CGEN_CPU_OPEN_BFDMACH: specify 1 mach using bfd name
+   CGEN_CPU_OPEN_ENDIAN:  specify endian choice
+   CGEN_CPU_OPEN_END:     terminates arguments
+
+   ??? Simultaneous multiple isas might not make sense, but it's not (yet)
+   precluded.
+
+   ??? We only support ISO C stdargs here, not K&R.
+   Laziness, plus experiment to see if anything requires K&R - eventually
+   K&R will no longer be supported - e.g. GDB is currently trying this.  */
+
+CGEN_CPU_DESC
+nios_cgen_cpu_open (enum cgen_cpu_open_arg arg_type, ...)
+{
+  CGEN_CPU_TABLE *cd = (CGEN_CPU_TABLE *) xmalloc (sizeof (CGEN_CPU_TABLE));
+  static int init_p;
+  unsigned int isas = 0;  /* 0 = "unspecified" */
+  unsigned int machs = 0; /* 0 = "unspecified" */
+  enum cgen_endian endian = CGEN_ENDIAN_UNKNOWN;
+  va_list ap;
+
+  if (! init_p)
+    {
+      init_tables ();
+      init_p = 1;
+    }
+
+  memset (cd, 0, sizeof (*cd));
+
+  va_start (ap, arg_type);
+  while (arg_type != CGEN_CPU_OPEN_END)
+    {
+      switch (arg_type)
+	{
+	case CGEN_CPU_OPEN_ISAS :
+	  isas = va_arg (ap, unsigned int);
+	  break;
+	case CGEN_CPU_OPEN_MACHS :
+	  machs = va_arg (ap, unsigned int);
+	  break;
+	case CGEN_CPU_OPEN_BFDMACH :
+	  {
+	    const char *name = va_arg (ap, const char *);
+	    const CGEN_MACH *mach =
+	      lookup_mach_via_bfd_name (nios_cgen_mach_table, name);
+
+	    machs |= mach->num << 1;
+	    break;
+	  }
+	case CGEN_CPU_OPEN_ENDIAN :
+	  endian = va_arg (ap, enum cgen_endian);
+	  break;
+	default :
+	  fprintf (stderr, "nios_cgen_cpu_open: unsupported argument `%d'\n",
+		   arg_type);
+	  abort (); /* ??? return NULL? */
+	}
+      arg_type = va_arg (ap, enum cgen_cpu_open_arg);
+    }
+  va_end (ap);
+
+  /* mach unspecified means "all" */
+  if (machs == 0)
+    machs = (1 << MAX_MACHS) - 1;
+  /* base mach is always selected */
+  machs |= 1;
+  /* isa unspecified means "all" */
+  if (isas == 0)
+    isas = (1 << MAX_ISAS) - 1;
+  if (endian == CGEN_ENDIAN_UNKNOWN)
+    {
+      /* ??? If target has only one, could have a default.  */
+      fprintf (stderr, "nios_cgen_cpu_open: no endianness specified\n");
+      abort ();
+    }
+
+  cd->isas = isas;
+  cd->machs = machs;
+  cd->endian = endian;
+  /* FIXME: for the sparc case we can determine insn-endianness statically.
+     The worry here is where both data and insn endian can be independently
+     chosen, in which case this function will need another argument.
+     Actually, will want to allow for more arguments in the future anyway.  */
+  cd->insn_endian = endian;
+
+  /* Table (re)builder.  */
+  cd->rebuild_tables = nios_cgen_rebuild_tables;
+  nios_cgen_rebuild_tables (cd);
+
+  /* Default to not allowing signed overflow.  */
+  cd->signed_overflow_ok_p = 0;
+  
+  return (CGEN_CPU_DESC) cd;
+}
+
+/* Cover fn to nios_cgen_cpu_open to handle the simple case of 1 isa, 1 mach.
+   MACH_NAME is the bfd name of the mach.  */
+
+CGEN_CPU_DESC
+nios_cgen_cpu_open_1 (mach_name, endian)
+     const char *mach_name;
+     enum cgen_endian endian;
+{
+  return nios_cgen_cpu_open (CGEN_CPU_OPEN_BFDMACH, mach_name,
+			       CGEN_CPU_OPEN_ENDIAN, endian,
+			       CGEN_CPU_OPEN_END);
+}
+
+/* Close a cpu table.
+   ??? This can live in a machine independent file, but there's currently
+   no place to put this file (there's no libcgen).  libopcodes is the wrong
+   place as some simulator ports use this but they don't use libopcodes.  */
+
+void
+nios_cgen_cpu_close (cd)
+     CGEN_CPU_DESC cd;
+{
+  if (cd->insn_table.init_entries)
+    free ((CGEN_INSN *) cd->insn_table.init_entries);
+  if (cd->hw_table.entries)
+    free ((CGEN_HW_ENTRY *) cd->hw_table.entries);
+  free (cd);
+}
+

--- a/libr/asm/arch/nios/gnu/nios-desc.h
+++ b/libr/asm/arch/nios/gnu/nios-desc.h
@@ -1,0 +1,303 @@
+/* CPU data header for nios.
+
+THIS FILE IS MACHINE GENERATED WITH CGEN.
+
+Copyright (C) 1996, 1997, 1998, 1999, 2001 Free Software Foundation, Inc.
+
+This file is part of the GNU Binutils and/or GDB, the GNU debugger.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#ifndef NIOS_CPU_H
+#define NIOS_CPU_H
+
+#define CGEN_ARCH nios
+
+/* Given symbol S, return nios_cgen_<S>.  */
+#define CGEN_SYM(s) CONCAT3 (nios,_cgen_,s)
+
+/* Selected cpu families.  */
+#define HAVE_CPU_NIOS16BF
+#define HAVE_CPU_NIOS32BF
+
+#define CGEN_INSN_LSB0_P 1
+
+/* Minimum size of any insn (in bytes).  */
+#define CGEN_MIN_INSN_SIZE 2
+
+/* Maximum size of any insn (in bytes).  */
+#define CGEN_MAX_INSN_SIZE 2
+
+#define CGEN_INT_INSN_P 1
+
+/* Maximum nymber of syntax bytes in an instruction.  */
+#define CGEN_ACTUAL_MAX_SYNTAX_BYTES 16
+
+/* CGEN_MNEMONIC_OPERANDS is defined if mnemonics have operands.
+   e.g. In "b,a foo" the ",a" is an operand.  If mnemonics have operands
+   we can't hash on everything up to the space.  */
+#define CGEN_MNEMONIC_OPERANDS
+
+/* Maximum number of fields in an instruction.  */
+#define CGEN_ACTUAL_MAX_IFMT_OPERANDS 4
+
+/* Enums.  */
+
+/* Enum declaration for insn op6 enums.  */
+typedef enum insn_op6 {
+  OP_ADD = 0, OP_ADDI = 1, OP_SUB = 2, OP_SUBI = 3
+ , OP_CMP = 4, OP_CMPI = 5, OP_LSL = 6, OP_LSLI = 7
+ , OP_LSR = 8, OP_LSRI = 9, OP_ASR = 10, OP_ASRI = 11
+ , OP_MOV = 12, OP_MOVI = 13, OP_AND = 14, OP_ANDN = 15
+ , OP_OR = 16, OP_XOR = 17, OP_BGEN = 18, OP_EXT8D = 19
+ , OP_SKP0 = 20, OP_SKP1 = 21, OP_LD = 22, OP_ST = 23
+ , OP_STS8S = 24, OP_STS16S = 25, OP_ADDC = 26, OP_EXT16D = 26
+ , OP_SUBC = 27, OP_MOVHI = 27, OP_USR0 = 28
+} INSN_OP6;
+
+/* Enum declaration for insn pfx enum.  */
+typedef enum insn_pfx_hi {
+  OP_PFX_HI = 19
+} INSN_PFX_HI;
+
+/* Enum declaration for insn op3 enums.  */
+typedef enum insn_op3 {
+  OP_STS = 6, OP_LDS = 7
+} INSN_OP3;
+
+/* Enum declaration for insn op4 enums.  */
+typedef enum insn_op4 {
+  OP_STP = 10, OP_LDP = 11
+} INSN_OP4;
+
+/* Enum declaration for insn op5 enums.  */
+typedef enum insn_op5 {
+  OP_BR = 16, OP_BSR = 17, OP_PFXIO = 18, OP_PFX = 19
+} INSN_OP5;
+
+/* Enum declaration for insn op8 enums.  */
+typedef enum insn_op8 {
+  OP_SAVE = 120, OP_TRAP = 121, OP_JMPC = 122, OP_CALLC = 123
+} INSN_OP8;
+
+/* Enum declaration for insn op9 enums.  */
+typedef enum insn_op9 {
+  OP_EXT8S = 232, OP_EXT16S = 233, OP_ST8S = 236, OP_ST16S = 237
+} INSN_OP9;
+
+/* Enum declaration for insn op11 enums.  */
+typedef enum insn_op11 {
+  OP_NOT = 992, OP_NEG = 993, OP_ABS = 994, OP_SEXT8 = 995
+ , OP_SEXT16 = 996, OP_RLC = 997, OP_RRC = 998, OP_TRET = 1006
+ , OP_RESTORE = 1005, OP_ST8D = 1008, OP_ST16D = 1009, OP_FILL8 = 1010
+ , OP_FILL16 = 1011, OP_LDM = 1012, OP_STM = 1013, OP_SKPRZ = 1014
+ , OP_SKPS = 1015, OP_WRCTL = 1016, OP_RDCTL = 1017, OP_SKPRNZ = 1018
+ , OP_JMP = 1022, OP_CALL = 1023, OP_SWAP = 1000, OP_USR1 = 1001
+ , OP_USR2 = 1002, OP_USR3 = 1003, OP_USR4 = 1004, OP_MSTEP = 1012
+ , OP_MUL = 1013
+} INSN_OP11;
+
+/* Enum declaration for .  */
+typedef enum ctl_names {
+  H_CTL__CTL0 = 0, H_CTL__CTL1 = 1, H_CTL__CTL2 = 2, H_CTL__CTL3 = 3
+ , H_CTL__CTL4 = 4, H_CTL__CTL5 = 5, H_CTL__STATUS = 0, H_CTL__ISTATUS = 1
+ , H_CTL__WVALID = 2, H_CTL__CD_BANK = 3, H_CTL__ST_BANK = 4, H_CTL__LD_BANK = 5
+} CTL_NAMES;
+
+/* Enum declaration for .  */
+typedef enum gr_names {
+  H_GR__SP = 14, H_GR__FP = 30, H_GR__G0 = 0, H_GR__G1 = 1
+ , H_GR__G2 = 2, H_GR__G3 = 3, H_GR__G4 = 4, H_GR__G5 = 5
+ , H_GR__G6 = 6, H_GR__G7 = 7, H_GR__R0 = 0, H_GR__R1 = 1
+ , H_GR__R2 = 2, H_GR__R3 = 3, H_GR__R4 = 4, H_GR__R5 = 5
+ , H_GR__R6 = 6, H_GR__R7 = 7, H_GR__O0 = 8, H_GR__O1 = 9
+ , H_GR__O2 = 10, H_GR__O3 = 11, H_GR__O4 = 12, H_GR__O5 = 13
+ , H_GR__O6 = 14, H_GR__O7 = 15, H_GR__R8 = 8, H_GR__R9 = 9
+ , H_GR__R10 = 10, H_GR__R11 = 11, H_GR__R12 = 12, H_GR__R13 = 13
+ , H_GR__R14 = 14, H_GR__R15 = 15, H_GR__L0 = 16, H_GR__L1 = 17
+ , H_GR__L2 = 18, H_GR__L3 = 19, H_GR__L4 = 20, H_GR__L5 = 21
+ , H_GR__L6 = 22, H_GR__L7 = 23, H_GR__R16 = 16, H_GR__R17 = 17
+ , H_GR__R18 = 18, H_GR__R19 = 19, H_GR__R20 = 20, H_GR__R21 = 21
+ , H_GR__R22 = 22, H_GR__R23 = 23, H_GR__I0 = 24, H_GR__I1 = 25
+ , H_GR__I2 = 26, H_GR__I3 = 27, H_GR__I4 = 28, H_GR__I5 = 29
+ , H_GR__I6 = 30, H_GR__I7 = 31, H_GR__R24 = 24, H_GR__R25 = 25
+ , H_GR__R26 = 26, H_GR__R27 = 27, H_GR__R28 = 28, H_GR__R29 = 29
+ , H_GR__R30 = 30, H_GR__R31 = 31
+} GR_NAMES;
+
+/* Enum declaration for .  */
+typedef enum gr0_name {
+  H_GR0__R0
+} GR0_NAME;
+
+/* Enum declaration for .  */
+typedef enum bp_names {
+  H_BP__L0 = 0, H_BP__L1 = 1, H_BP__L2 = 2, H_BP__L3 = 3
+ , H_BP__R16 = 0, H_BP__R17 = 1, H_BP__R18 = 2, H_BP__R19 = 3
+} BP_NAMES;
+
+/* Attributes.  */
+
+/* Enum declaration for machine type selection.  */
+typedef enum mach_attr {
+  MACH_BASE, MACH_NIOS16, MACH_NIOS32, MACH_MAX
+} MACH_ATTR;
+
+/* Enum declaration for instruction set selection.  */
+typedef enum isa_attr {
+  ISA_NIOS, ISA_MAX
+} ISA_ATTR;
+
+/* Number of architecture variants.  */
+#define MAX_ISAS  1
+#define MAX_MACHS ((int) MACH_MAX)
+
+/* Ifield support.  */
+
+/* Ifield attribute indices.  */
+
+/* Enum declaration for cgen_ifld attrs.  */
+typedef enum cgen_ifld_attr {
+  CGEN_IFLD_VIRTUAL, CGEN_IFLD_PCREL_ADDR, CGEN_IFLD_ABS_ADDR, CGEN_IFLD_RESERVED
+ , CGEN_IFLD_SIGN_OPT, CGEN_IFLD_SIGNED, CGEN_IFLD_END_BOOLS, CGEN_IFLD_START_NBOOLS = 31
+ , CGEN_IFLD_MACH, CGEN_IFLD_END_NBOOLS
+} CGEN_IFLD_ATTR;
+
+/* Number of non-boolean elements in cgen_ifld_attr.  */
+#define CGEN_IFLD_NBOOL_ATTRS (CGEN_IFLD_END_NBOOLS - CGEN_IFLD_START_NBOOLS - 1)
+
+/* Enum declaration for nios ifield types.  */
+typedef enum ifield_type {
+  NIOS_F_NIL, NIOS_F_ANYOF, NIOS_F_OP6, NIOS_F_OP3
+ , NIOS_F_OP4, NIOS_F_OP5, NIOS_F_OP5_HI, NIOS_F_OP8
+ , NIOS_F_OP9, NIOS_F_OP11, NIOS_F_RA, NIOS_F_RB
+ , NIOS_F_RBI5, NIOS_F_RZ, NIOS_F_RP, NIOS_F_CTLC
+ , NIOS_F_I2, NIOS_F_I4W, NIOS_F_X1, NIOS_F_O1
+ , NIOS_F_O2, NIOS_F_I5, NIOS_F_I6V, NIOS_F_I8
+ , NIOS_F_I8V, NIOS_F_I9, NIOS_F_I10, NIOS_F_I11
+ , NIOS_F_I6_REL_H, NIOS_F_I6_REL_W, NIOS_F_BSRR_I6_REL, NIOS_F_I8V_REL_H
+ , NIOS_F_I8V_REL_W, NIOS_F_I11_REL, NIOS_F_I1, NIOS_F_MAX
+} IFIELD_TYPE;
+
+#define MAX_IFLD ((int) NIOS_F_MAX)
+
+/* Hardware attribute indices.  */
+
+/* Enum declaration for cgen_hw attrs.  */
+typedef enum cgen_hw_attr {
+  CGEN_HW_VIRTUAL, CGEN_HW_CACHE_ADDR, CGEN_HW_PC, CGEN_HW_PROFILE
+ , CGEN_HW_END_BOOLS, CGEN_HW_START_NBOOLS = 31, CGEN_HW_MACH, CGEN_HW_END_NBOOLS
+} CGEN_HW_ATTR;
+
+/* Number of non-boolean elements in cgen_hw_attr.  */
+#define CGEN_HW_NBOOL_ATTRS (CGEN_HW_END_NBOOLS - CGEN_HW_START_NBOOLS - 1)
+
+/* Enum declaration for nios hardware types.  */
+typedef enum cgen_hw_type {
+  HW_H_MEMORY, HW_H_SINT, HW_H_UINT, HW_H_ADDR
+ , HW_H_IADDR, HW_H_PC, HW_H_CWP, HW_H_OLD_CWP
+ , HW_H_IPRI, HW_H_ZERO, HW_H_TEBIT, HW_H_NBIT
+ , HW_H_ZBIT, HW_H_VBIT, HW_H_CBIT, HW_H_PBIT
+ , HW_H_SBIT, HW_H_WBIT, HW_H_STATUS, HW_H_K
+ , HW_H_M16_GR, HW_H_M16_GR0, HW_H_M16_BP, HW_H_M16_RZ
+ , HW_H_M16_SP, HW_H_M16_CTL, HW_H_M32_GR, HW_H_M32_GR0
+ , HW_H_M32_BP, HW_H_M32_RZ, HW_H_M32_SP, HW_H_M32_CTL
+ , HW_MAX
+} CGEN_HW_TYPE;
+
+#define MAX_HW ((int) HW_MAX)
+
+/* Operand attribute indices.  */
+
+/* Enum declaration for cgen_operand attrs.  */
+typedef enum cgen_operand_attr {
+  CGEN_OPERAND_VIRTUAL, CGEN_OPERAND_PCREL_ADDR, CGEN_OPERAND_ABS_ADDR, CGEN_OPERAND_SIGN_OPT
+ , CGEN_OPERAND_SIGNED, CGEN_OPERAND_NEGATIVE, CGEN_OPERAND_RELAX, CGEN_OPERAND_SEM_ONLY
+ , CGEN_OPERAND_HASH_PREFIX, CGEN_OPERAND_END_BOOLS, CGEN_OPERAND_START_NBOOLS = 31, CGEN_OPERAND_MACH
+ , CGEN_OPERAND_END_NBOOLS
+} CGEN_OPERAND_ATTR;
+
+/* Number of non-boolean elements in cgen_operand_attr.  */
+#define CGEN_OPERAND_NBOOL_ATTRS (CGEN_OPERAND_END_NBOOLS - CGEN_OPERAND_START_NBOOLS - 1)
+
+/* Enum declaration for nios operand types.  */
+typedef enum cgen_operand_type {
+  NIOS_OPERAND_PC, NIOS_OPERAND_K, NIOS_OPERAND_CTLC, NIOS_OPERAND_XRA
+ , NIOS_OPERAND_X1, NIOS_OPERAND_O1, NIOS_OPERAND_O2, NIOS_OPERAND_I1
+ , NIOS_OPERAND_I2, NIOS_OPERAND_SI5, NIOS_OPERAND_I8, NIOS_OPERAND_I8V
+ , NIOS_OPERAND_I6V, NIOS_OPERAND_SI11, NIOS_OPERAND_REL11, NIOS_OPERAND_BSRR_REL6
+ , NIOS_OPERAND_NBIT, NIOS_OPERAND_VBIT, NIOS_OPERAND_ZBIT, NIOS_OPERAND_CBIT
+ , NIOS_OPERAND_TEBIT, NIOS_OPERAND_PBIT, NIOS_OPERAND_SBIT, NIOS_OPERAND_WBIT
+ , NIOS_OPERAND_I4W, NIOS_OPERAND_I4WN, NIOS_OPERAND_I5, NIOS_OPERAND_SAVE_I8V
+ , NIOS_OPERAND_I11, NIOS_OPERAND_I10, NIOS_OPERAND_I9, NIOS_OPERAND_I16
+ , NIOS_OPERAND_I32, NIOS_OPERAND_RBI5, NIOS_OPERAND_M16_RA, NIOS_OPERAND_M16_RB
+ , NIOS_OPERAND_M16_R0, NIOS_OPERAND_M16_SP, NIOS_OPERAND_M16_RP, NIOS_OPERAND_M16_RZ
+ , NIOS_OPERAND_M16_I6, NIOS_OPERAND_M16_I8V, NIOS_OPERAND_M32_RA, NIOS_OPERAND_M32_RB
+ , NIOS_OPERAND_M32_R0, NIOS_OPERAND_M32_SP, NIOS_OPERAND_M32_RP, NIOS_OPERAND_M32_RZ
+ , NIOS_OPERAND_M32_I6, NIOS_OPERAND_M32_I8V, NIOS_OPERAND_MAX
+} CGEN_OPERAND_TYPE;
+
+/* Number of operands types.  */
+#define MAX_OPERANDS ((int) NIOS_OPERAND_MAX)
+
+/* Maximum number of operands referenced by any insn.  */
+#define MAX_OPERAND_INSTANCES 8
+
+/* Insn attribute indices.  */
+
+/* Enum declaration for cgen_insn attrs.  */
+typedef enum cgen_insn_attr {
+  CGEN_INSN_ALIAS, CGEN_INSN_VIRTUAL, CGEN_INSN_UNCOND_CTI, CGEN_INSN_COND_CTI
+ , CGEN_INSN_SKIP_CTI, CGEN_INSN_DELAY_SLOT, CGEN_INSN_RELAXABLE, CGEN_INSN_RELAX
+ , CGEN_INSN_NO_DIS, CGEN_INSN_PBB, CGEN_INSN_PREFIX, CGEN_INSN_PREFIXED_INSN
+ , CGEN_INSN_SKIP_INSN, CGEN_INSN_DUAL_MODE, CGEN_INSN_END_BOOLS, CGEN_INSN_START_NBOOLS = 31
+ , CGEN_INSN_MACH, CGEN_INSN_END_NBOOLS
+} CGEN_INSN_ATTR;
+
+/* Number of non-boolean elements in cgen_insn_attr.  */
+#define CGEN_INSN_NBOOL_ATTRS (CGEN_INSN_END_NBOOLS - CGEN_INSN_START_NBOOLS - 1)
+
+/* cgen.h uses things we just defined.  */
+#include "opcode/cgen.h"
+
+extern const struct cgen_ifld nios_cgen_ifld_table[];
+
+/* Attributes.  */
+extern const CGEN_ATTR_TABLE nios_cgen_hardware_attr_table[];
+extern const CGEN_ATTR_TABLE nios_cgen_ifield_attr_table[];
+extern const CGEN_ATTR_TABLE nios_cgen_operand_attr_table[];
+extern const CGEN_ATTR_TABLE nios_cgen_insn_attr_table[];
+
+/* Hardware decls.  */
+
+extern CGEN_KEYWORD nios_cgen_opval_gr_names;
+extern CGEN_KEYWORD nios_cgen_opval_h_m16_gr0;
+extern CGEN_KEYWORD nios_cgen_opval_bp_names;
+extern CGEN_KEYWORD nios_cgen_opval_gr_names;
+extern CGEN_KEYWORD nios_cgen_opval_h_m16_sp;
+extern CGEN_KEYWORD nios_cgen_opval_ctl_names;
+extern CGEN_KEYWORD nios_cgen_opval_gr_names;
+extern CGEN_KEYWORD nios_cgen_opval_gr0_name;
+extern CGEN_KEYWORD nios_cgen_opval_bp_names;
+extern CGEN_KEYWORD nios_cgen_opval_gr_names;
+extern CGEN_KEYWORD nios_cgen_opval_h_m32_sp;
+extern CGEN_KEYWORD nios_cgen_opval_ctl_names;
+
+
+
+
+#endif /* NIOS_CPU_H */

--- a/libr/asm/arch/nios/gnu/nios-desc.h
+++ b/libr/asm/arch/nios/gnu/nios-desc.h
@@ -2,33 +2,37 @@
 
 THIS FILE IS MACHINE GENERATED WITH CGEN.
 
-Copyright (C) 1996, 1997, 1998, 1999, 2001 Free Software Foundation, Inc.
+Copyright (C) 1996-2018 Free Software Foundation, Inc.
 
 This file is part of the GNU Binutils and/or GDB, the GNU debugger.
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2, or (at your option)
-any later version.
+   This file is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3, or (at your option)
+   any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+   It is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+   License for more details.
 
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.
 
 */
 
 #ifndef NIOS_CPU_H
 #define NIOS_CPU_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CGEN_ARCH nios
 
 /* Given symbol S, return nios_cgen_<S>.  */
-#define CGEN_SYM(s) CONCAT3 (nios,_cgen_,s)
+#define CGEN_SYM(s) nios##_cgen_##s
 
 /* Selected cpu families.  */
 #define HAVE_CPU_NIOS16BF
@@ -44,8 +48,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define CGEN_INT_INSN_P 1
 
-/* Maximum nymber of syntax bytes in an instruction.  */
-#define CGEN_ACTUAL_MAX_SYNTAX_BYTES 16
+/* Maximum number of syntax elements in an instruction.  */
+#define CGEN_ACTUAL_MAX_SYNTAX_ELEMENTS 16
 
 /* CGEN_MNEMONIC_OPERANDS is defined if mnemonics have operands.
    e.g. In "b,a foo" the ",a" is an operand.  If mnemonics have operands
@@ -262,7 +266,7 @@ typedef enum cgen_operand_type {
 /* Enum declaration for cgen_insn attrs.  */
 typedef enum cgen_insn_attr {
   CGEN_INSN_ALIAS, CGEN_INSN_VIRTUAL, CGEN_INSN_UNCOND_CTI, CGEN_INSN_COND_CTI
- , CGEN_INSN_SKIP_CTI, CGEN_INSN_DELAY_SLOT, CGEN_INSN_RELAXABLE, CGEN_INSN_RELAX
+ , CGEN_INSN_SKIP_CTI, CGEN_INSN_DELAY_SLOT, CGEN_INSN_RELAXABLE, CGEN_INSN_RELAXED
  , CGEN_INSN_NO_DIS, CGEN_INSN_PBB, CGEN_INSN_PREFIX, CGEN_INSN_PREFIXED_INSN
  , CGEN_INSN_SKIP_INSN, CGEN_INSN_DUAL_MODE, CGEN_INSN_END_BOOLS, CGEN_INSN_START_NBOOLS = 31
  , CGEN_INSN_MACH, CGEN_INSN_END_NBOOLS
@@ -297,7 +301,15 @@ extern CGEN_KEYWORD nios_cgen_opval_gr_names;
 extern CGEN_KEYWORD nios_cgen_opval_h_m32_sp;
 extern CGEN_KEYWORD nios_cgen_opval_ctl_names;
 
+extern const CGEN_HW_ENTRY nios_cgen_hw_table[];
 
+#ifndef opcodes_error_handler
+#define opcodes_error_handler(...) \
+  fprintf (stderr, __VA_ARGS__); fputc ('\n', stderr)
+#endif
 
+   #ifdef __cplusplus
+   }
+   #endif
 
 #endif /* NIOS_CPU_H */

--- a/libr/asm/arch/nios/gnu/nios-dis.c
+++ b/libr/asm/arch/nios/gnu/nios-dis.c
@@ -1,75 +1,91 @@
-/* Disassembler interface for targets using CGEN. -*- C -*-
-   CGEN: Cpu tools GENerator
+/* Altera Nios disassemble routines
+   Copyright (C) 2012-2018 Free Software Foundation, Inc.
 
-THIS FILE IS MACHINE GENERATED WITH CGEN.
-- the resultant file is machine generated, cgen-dis.in isn't
+   THIS FILE IS MACHINE GENERATED WITH CGEN.
+   - the resultant file is machine generated, cgen-dis.in isn't
 
-Copyright (C) 1996, 1997, 1998, 1999 Free Software Foundation, Inc.
+   Copyright (C) 1996-2018 Free Software Foundation, Inc.
 
-This file is part of the GNU Binutils and GDB, the GNU debugger.
+   This file is part of libopcodes.
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2, or (at your option)
-any later version.
+   This library is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3, or (at your option)
+   any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+   It is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+   License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software Foundation, Inc.,
-59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.  */
 
 /* ??? Eventually more and more of this stuff can go to cpu-independent files.
    Keep that in mind.  */
 
 #include "sysdep.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include "ansidecl.h"
 #include "dis-asm.h"
 //#include "bfd.h"
 #include "mybfd.h"
 #include "symcat.h"
+#include "libiberty.h"
 #include "nios-desc.h"
 #include "nios-opc.h"
 #include "opintl.h"
+
+extern const bfd_arch_info_type bfd_nios_arch;
+
+const bfd_arch_info_type *
+bfd_lookup_arch (enum bfd_architecture arch, unsigned long machine)
+{
+  if (arch != bfd_arch_nios) {
+    return NULL;
+  }
+
+  if (machine == MACH_NIOS16) {
+    return &bfd_nios_arch;
+  } else if (machine == MACH_NIOS32) {
+    return bfd_nios_arch.next;
+  } else {
+    return NULL;
+  }
+}
 
 /* Default text to print if an instruction isn't recognized.  */
 #define UNKNOWN_INSN_MSG _("*unknown*")
 
 static void print_normal
-     PARAMS ((CGEN_CPU_DESC, PTR, long, unsigned int, bfd_vma, int));
+  (CGEN_CPU_DESC, void *, long, unsigned int, bfd_vma, int);
 static void print_address
-     PARAMS ((CGEN_CPU_DESC, PTR, bfd_vma, unsigned int, bfd_vma, int));
+  (CGEN_CPU_DESC, void *, bfd_vma, unsigned int, bfd_vma, int) ATTRIBUTE_UNUSED;
 static void print_keyword
-     PARAMS ((CGEN_CPU_DESC, PTR, CGEN_KEYWORD *, long, unsigned int));
+  (CGEN_CPU_DESC, void *, CGEN_KEYWORD *, long, unsigned int) ATTRIBUTE_UNUSED;
 static void print_insn_normal
-     PARAMS ((CGEN_CPU_DESC, PTR, const CGEN_INSN *, CGEN_FIELDS *,
-	      bfd_vma, int));
-static int print_insn PARAMS ((CGEN_CPU_DESC, bfd_vma,
-			       disassemble_info *, char *, int));
+  (CGEN_CPU_DESC, void *, const CGEN_INSN *, CGEN_FIELDS *, bfd_vma, int);
+static int print_insn
+  (CGEN_CPU_DESC, bfd_vma,  disassemble_info *, bfd_byte *, unsigned);
 static int default_print_insn
-     PARAMS ((CGEN_CPU_DESC, bfd_vma, disassemble_info *));
+  (CGEN_CPU_DESC, bfd_vma, disassemble_info *) ATTRIBUTE_UNUSED;
+static int read_insn
+  (CGEN_CPU_DESC, bfd_vma, disassemble_info *, bfd_byte *, int, CGEN_EXTRACT_INFO *,
+   unsigned long *);
 
-/* -- disassembler routines inserted here */
+/* -- disassembler routines inserted here.  */
 
 /* -- dis.c */
 
 /* Include "%hi(foo) in output.  */
       
-static void
-print_Rbi5 (cd, dis_info, value, attrs, pc, length)
-     CGEN_CPU_DESC cd;
-     PTR dis_info;
-     long value;
-     unsigned int attrs;
-     bfd_vma pc;
-     int length;
+ATTRIBUTE_UNUSED static void
+print_Rbi5 (CGEN_CPU_DESC cd, void *dis_info, long value, unsigned int attrs, bfd_vma pc, int length)
 {
   int status;
-  char buf[2];
+  bfd_byte buf[2];
   unsigned long insn_value;
   const CGEN_INSN_LIST *insn_list;
 
@@ -85,7 +101,7 @@ print_Rbi5 (cd, dis_info, value, attrs, pc, length)
 	  return;
 	}
       insn_value = info->endian == BFD_ENDIAN_BIG ? bfd_getb16 (buf) : bfd_getl16 (buf);
-      insn_list = CGEN_DIS_LOOKUP_INSN (cd, buf, insn_value);
+      insn_list = CGEN_DIS_LOOKUP_INSN (cd, (char *) buf, insn_value);
       while (insn_list != NULL)
 	{
 	  const CGEN_INSN *insn = insn_list->insn;
@@ -97,7 +113,7 @@ print_Rbi5 (cd, dis_info, value, attrs, pc, length)
 	      == CGEN_INSN_BASE_VALUE (insn))
 	    {
 	      if (CGEN_INSN_ATTR_VALUE (insn, CGEN_INSN_PREFIX))
-		(*info->fprintf_func) (info->stream, "0x%x", value);
+		(*info->fprintf_func) (info->stream, "0x%lx", value);
 	      else
 		print_keyword (cd, info, & nios_cgen_opval_gr_names, value, 0);
 	      return;
@@ -108,66 +124,41 @@ print_Rbi5 (cd, dis_info, value, attrs, pc, length)
   print_keyword (cd, info, & nios_cgen_opval_gr_names, value, 0);
 }
 
-static void
-print_i11 (cd, dis_info, value, attrs, pc, length)
-     CGEN_CPU_DESC cd;
-     PTR dis_info;
-     long value;
-     unsigned int attrs;
-     bfd_vma pc;
-     int length;
+ATTRIBUTE_UNUSED static void
+print_i11 (CGEN_CPU_DESC cd, void *dis_info, long value, unsigned int attrs, bfd_vma pc, int length)
 {
   disassemble_info *info = (disassemble_info *) dis_info;
-  (*info->fprintf_func) (info->stream, "%%hi(0x%lx)", value << 5);
+  (*info->fprintf_func) (info->stream, "hi(0x%lx)", value << 5);
 }
 
-static void
-print_r0 (cd, dis_info, value, attrs, pc, length)
-     CGEN_CPU_DESC cd;
-     PTR dis_info;
-     long value;
-     unsigned int attrs;
-     bfd_vma pc;
-     int length;
+ATTRIBUTE_UNUSED static void
+print_r0 (CGEN_CPU_DESC cd, void *dis_info, long value, unsigned int attrs, bfd_vma pc, int length)
 {
   disassemble_info *info = (disassemble_info *) dis_info;
-  (*info->fprintf_func) (info->stream, "%g0");
+  (*info->fprintf_func) (info->stream, "g0");
 }
 
-static void
-print_i16 (cd, dis_info, value, attrs, pc, length)
-     CGEN_CPU_DESC cd;
-     PTR dis_info;
-     long value;
-     unsigned int attrs;
-     bfd_vma pc;
-     int length;
+ATTRIBUTE_UNUSED static void
+print_i16 (CGEN_CPU_DESC cd, void *dis_info, long value, unsigned int attrs, bfd_vma pc, int length)
 {
   disassemble_info *info = (disassemble_info *) dis_info;
   (*info->fprintf_func) (info->stream, "#0x%hx)", (short)value);
 }
 
-static void
-print_i32 (cd, dis_info, value, attrs, pc, length)
-     CGEN_CPU_DESC cd;
-     PTR dis_info;
-     long value;
-     unsigned int attrs;
-     bfd_vma pc;
-     int length;
+ATTRIBUTE_UNUSED static void
+print_i32 (CGEN_CPU_DESC cd ATTRIBUTE_UNUSED,
+		    void *dis_info,
+		    long value,
+		    unsigned int attrs,
+		    bfd_vma pc,
+		    int length)
 {
   disassemble_info *info = (disassemble_info *) dis_info;
   (*info->fprintf_func) (info->stream, "#0x%lx)", value);
 }
 
-static void
-print_i4w (cd, dis_info, value, attrs, pc, length)
-     CGEN_CPU_DESC cd;
-     PTR dis_info;
-     long value;
-     unsigned int attrs;
-     bfd_vma pc;
-     int length;
+ATTRIBUTE_UNUSED static void
+print_i4w (CGEN_CPU_DESC cd, void *dis_info, long value, unsigned int attrs, bfd_vma pc, int length)
 {
   char *str;
   disassemble_info *info = (disassemble_info *) dis_info;
@@ -220,10 +211,14 @@ print_i4w (cd, dis_info, value, attrs, pc, length)
   if (str != NULL)
     (*info->fprintf_func) (info->stream, "%s", str);
   else
-    (*info->fprintf_func) (info->stream, "0x%x", value);
+    (*info->fprintf_func) (info->stream, "0x%lx", value);
 }
 
+
 /* -- */
+
+void nios_cgen_print_operand
+  (CGEN_CPU_DESC, int, PTR, CGEN_FIELDS *, void const *, bfd_vma, int);
 
 /* Main entry point for printing operands.
    XINFO is a `void *' and not a `disassemble_info *' to not put a requirement
@@ -238,18 +233,16 @@ print_i4w (cd, dis_info, value, attrs, pc, length)
 
    This function could be moved into `print_insn_normal', but keeping it
    separate makes clear the interface between `print_insn_normal' and each of
-   the handlers.
-*/
+   the handlers.  */
 
 void
-nios_cgen_print_operand (cd, opindex, xinfo, fields, attrs, pc, length)
-     CGEN_CPU_DESC cd;
-     int opindex;
-     PTR xinfo;
-     CGEN_FIELDS *fields;
-     void const *attrs;
-     bfd_vma pc;
-     int length;
+nios_cgen_print_operand (CGEN_CPU_DESC cd,
+			   int opindex,
+			   void * xinfo,
+			   CGEN_FIELDS *fields,
+			   void const *attrs ATTRIBUTE_UNUSED,
+			   bfd_vma pc,
+			   int length)
 {
  disassemble_info *info = (disassemble_info *) xinfo;
 
@@ -372,9 +365,10 @@ nios_cgen_print_operand (cd, opindex, xinfo, fields, attrs, pc, length)
 
     default :
       /* xgettext:c-format */
-      fprintf (stderr, _("Unrecognized field %d while printing insn.\n"),
-	       opindex);
-    abort ();
+      opcodes_error_handler
+	(_("internal error: unrecognized field %d while printing insn"),
+	 opindex);
+      abort ();
   }
 }
 
@@ -385,8 +379,7 @@ cgen_print_fn * const nios_cgen_print_handlers[] =
 
 
 void
-nios_cgen_init_dis (cd)
-     CGEN_CPU_DESC cd;
+nios_cgen_init_dis (CGEN_CPU_DESC cd)
 {
   nios_cgen_init_opcode_table (cd);
   nios_cgen_init_ibld_table (cd);
@@ -398,19 +391,14 @@ nios_cgen_init_dis (cd)
 /* Default print handler.  */
 
 static void
-print_normal (cd, dis_info, value, attrs, pc, length)
-     CGEN_CPU_DESC cd;
-     PTR dis_info;
-     long value;
-     unsigned int attrs;
-     bfd_vma pc;
-     int length;
+print_normal (CGEN_CPU_DESC cd ATTRIBUTE_UNUSED,
+	      void *dis_info,
+	      long value,
+	      unsigned int attrs,
+	      bfd_vma pc ATTRIBUTE_UNUSED,
+	      int length ATTRIBUTE_UNUSED)
 {
   disassemble_info *info = (disassemble_info *) dis_info;
-
-#ifdef CGEN_PRINT_NORMAL
-  CGEN_PRINT_NORMAL (cd, info, value, attrs, pc, length);
-#endif
 
   /* Print the operand as directed by the attributes.  */
   if (CGEN_BOOL_ATTR (attrs, CGEN_OPERAND_SEM_ONLY))
@@ -424,23 +412,18 @@ print_normal (cd, dis_info, value, attrs, pc, length)
 /* Default address handler.  */
 
 static void
-print_address (cd, dis_info, value, attrs, pc, length)
-     CGEN_CPU_DESC cd;
-     PTR dis_info;
-     bfd_vma value;
-     unsigned int attrs;
-     bfd_vma pc;
-     int length;
+print_address (CGEN_CPU_DESC cd ATTRIBUTE_UNUSED,
+	       void *dis_info,
+	       bfd_vma value,
+	       unsigned int attrs,
+	       bfd_vma pc ATTRIBUTE_UNUSED,
+	       int length ATTRIBUTE_UNUSED)
 {
   disassemble_info *info = (disassemble_info *) dis_info;
 
-#ifdef CGEN_PRINT_ADDRESS
-  CGEN_PRINT_ADDRESS (cd, info, value, attrs, pc, length);
-#endif
-
   /* Print the operand as directed by the attributes.  */
   if (CGEN_BOOL_ATTR (attrs, CGEN_OPERAND_SEM_ONLY))
-    ; /* nothing to do */
+    ; /* Nothing to do.  */
   else if (CGEN_BOOL_ATTR (attrs, CGEN_OPERAND_PCREL_ADDR))
     (*info->print_address_func) (value, info);
   else if (CGEN_BOOL_ATTR (attrs, CGEN_OPERAND_ABS_ADDR))
@@ -454,12 +437,11 @@ print_address (cd, dis_info, value, attrs, pc, length)
 /* Keyword print handler.  */
 
 static void
-print_keyword (cd, dis_info, keyword_table, value, attrs)
-     CGEN_CPU_DESC cd;
-     PTR dis_info;
-     CGEN_KEYWORD *keyword_table;
-     long value;
-     unsigned int attrs;
+print_keyword (CGEN_CPU_DESC cd ATTRIBUTE_UNUSED,
+	       void *dis_info,
+	       CGEN_KEYWORD *keyword_table,
+	       long value,
+	       unsigned int attrs ATTRIBUTE_UNUSED)
 {
   disassemble_info *info = (disassemble_info *) dis_info;
   const CGEN_KEYWORD_ENTRY *ke;
@@ -473,21 +455,20 @@ print_keyword (cd, dis_info, keyword_table, value, attrs)
 
 /* Default insn printer.
 
-   DIS_INFO is defined as `PTR' so the disassembler needn't know anything
+   DIS_INFO is defined as `void *' so the disassembler needn't know anything
    about disassemble_info.  */
 
 static void
-print_insn_normal (cd, dis_info, insn, fields, pc, length)
-     CGEN_CPU_DESC cd;
-     PTR dis_info;
-     const CGEN_INSN *insn;
-     CGEN_FIELDS *fields;
-     bfd_vma pc;
-     int length;
+print_insn_normal (CGEN_CPU_DESC cd,
+		   void *dis_info,
+		   const CGEN_INSN *insn,
+		   CGEN_FIELDS *fields,
+		   bfd_vma pc,
+		   int length)
 {
   const CGEN_SYNTAX *syntax = CGEN_INSN_SYNTAX (insn);
   disassemble_info *info = (disassemble_info *) dis_info;
-  const unsigned char *syn;
+  const CGEN_SYNTAX_CHAR_TYPE *syn;
 
   CGEN_INIT_PRINT (cd);
 
@@ -510,6 +491,35 @@ print_insn_normal (cd, dis_info, insn, fields, pc, length)
     }
 }
 
+/* Subroutine of print_insn. Reads an insn into the given buffers and updates
+   the extract info.
+   Returns 0 if all is well, non-zero otherwise.  */
+
+static int
+read_insn (CGEN_CPU_DESC cd ATTRIBUTE_UNUSED,
+	   bfd_vma pc,
+	   disassemble_info *info,
+	   bfd_byte *buf,
+	   int buflen,
+	   CGEN_EXTRACT_INFO *ex_info,
+	   unsigned long *insn_value)
+{
+  int status = (*info->read_memory_func) (pc, buf, buflen, info);
+
+  if (status != 0)
+    {
+      (*info->memory_error_func) (status, pc, info);
+      return -1;
+    }
+
+  ex_info->dis_info = info;
+  ex_info->valid = (1 << buflen) - 1;
+  ex_info->insn_bytes = buf;
+
+  *insn_value = bfd_get_bits (buf, buflen * 8, info->endian == BFD_ENDIAN_BIG);
+  return 0;
+}
+
 /* Utility to print an insn.
    BUF is the base part of the insn, target byte order, BUFLEN bytes long.
    The result is the size of the insn in bytes or zero for an unknown insn
@@ -517,48 +527,43 @@ print_insn_normal (cd, dis_info, insn, fields, pc, length)
    been called).  */
 
 static int
-print_insn (cd, pc, info, buf, buflen)
-     CGEN_CPU_DESC cd;
-     bfd_vma pc;
-     disassemble_info *info;
-     char *buf;
-     int buflen;
+print_insn (CGEN_CPU_DESC cd,
+	    bfd_vma pc,
+	    disassemble_info *info,
+	    bfd_byte *buf,
+	    unsigned int buflen)
 {
-  unsigned long insn_value;
+  CGEN_INSN_INT insn_value;
   const CGEN_INSN_LIST *insn_list;
   CGEN_EXTRACT_INFO ex_info;
+  int basesize;
 
+  /* Extract base part of instruction, just in case CGEN_DIS_* uses it. */
+  basesize = cd->base_insn_bitsize < buflen * 8 ?
+                                     cd->base_insn_bitsize : buflen * 8;
+  insn_value = cgen_get_insn_value (cd, buf, basesize);
+
+
+  /* Fill in ex_info fields like read_insn would.  Don't actually call
+     read_insn, since the incoming buffer is already read (and possibly
+     modified a la m32r).  */
+  ex_info.valid = (1 << buflen) - 1;
   ex_info.dis_info = info;
-  ex_info.valid = (1 << (cd->base_insn_bitsize / 8)) - 1;
   ex_info.insn_bytes = buf;
-
-  switch (buflen)
-    {
-    case 1:
-      insn_value = buf[0];
-      break;
-    case 2:
-      insn_value = info->endian == BFD_ENDIAN_BIG ? bfd_getb16 (buf) : bfd_getl16 (buf);
-      break;
-    case 4:
-      insn_value = info->endian == BFD_ENDIAN_BIG ? bfd_getb32 (buf) : bfd_getl32 (buf);
-      break;
-    default:
-      abort ();
-    }
 
   /* The instructions are stored in hash lists.
      Pick the first one and keep trying until we find the right one.  */
 
-  insn_list = CGEN_DIS_LOOKUP_INSN (cd, buf, insn_value);
+  insn_list = CGEN_DIS_LOOKUP_INSN (cd, (char *) buf, insn_value);
   while (insn_list != NULL)
     {
       const CGEN_INSN *insn = insn_list->insn;
       CGEN_FIELDS fields;
       int length;
+      unsigned long insn_value_cropped;
 
-#ifdef CGEN_VALIDATE_INSN_SUPPORTED 
-      /* not needed as insn shouldn't be in hash lists if not supported */
+#ifdef CGEN_VALIDATE_INSN_SUPPORTED
+      /* Not needed as insn shouldn't be in hash lists if not supported.  */
       /* Supported by this cpu?  */
       if (! nios_cgen_insn_supported (cd, insn))
         {
@@ -570,22 +575,48 @@ print_insn (cd, pc, info, buf, buflen)
       /* Basic bit mask must be correct.  */
       /* ??? May wish to allow target to defer this check until the extract
 	 handler.  */
-      if ((insn_value & CGEN_INSN_BASE_MASK (insn))
+
+      /* Base size may exceed this instruction's size.  Extract the
+         relevant part from the buffer. */
+      if ((unsigned) (CGEN_INSN_BITSIZE (insn) / 8) < buflen &&
+	  (unsigned) (CGEN_INSN_BITSIZE (insn) / 8) <= sizeof (unsigned long))
+	insn_value_cropped = bfd_get_bits (buf, CGEN_INSN_BITSIZE (insn),
+					   info->endian == BFD_ENDIAN_BIG);
+      else
+	insn_value_cropped = insn_value;
+
+      if ((insn_value_cropped & CGEN_INSN_BASE_MASK (insn))
 	  == CGEN_INSN_BASE_VALUE (insn))
 	{
 	  /* Printing is handled in two passes.  The first pass parses the
 	     machine insn and extracts the fields.  The second pass prints
 	     them.  */
 
-	  length = CGEN_EXTRACT_FN (cd, insn)
-	    (cd, insn, &ex_info, insn_value, &fields, pc);
-	  /* length < 0 -> error */
+	  /* Make sure the entire insn is loaded into insn_value, if it
+	     can fit.  */
+	  if (((unsigned) CGEN_INSN_BITSIZE (insn) > cd->base_insn_bitsize) &&
+	      (unsigned) (CGEN_INSN_BITSIZE (insn) / 8) <= sizeof (unsigned long))
+	    {
+	      unsigned long full_insn_value;
+	      int rc = read_insn (cd, pc, info, buf,
+				  CGEN_INSN_BITSIZE (insn) / 8,
+				  & ex_info, & full_insn_value);
+	      if (rc != 0)
+		return rc;
+	      length = CGEN_EXTRACT_FN (cd, insn)
+		(cd, insn, &ex_info, full_insn_value, &fields, pc);
+	    }
+	  else
+	    length = CGEN_EXTRACT_FN (cd, insn)
+	      (cd, insn, &ex_info, insn_value_cropped, &fields, pc);
+
+	  /* Length < 0 -> error.  */
 	  if (length < 0)
 	    return length;
 	  if (length > 0)
 	    {
 	      CGEN_PRINT_FN (cd, insn) (cd, info, insn, &fields, pc, length);
-	      /* length is in bits, result is in bytes */
+	      /* Length is in bits, result is in bytes.  */
 	      return length / 8;
 	    }
 	}
@@ -605,39 +636,57 @@ print_insn (cd, pc, info, buf, buflen)
 #endif
 
 static int
-default_print_insn (cd, pc, info)
-     CGEN_CPU_DESC cd;
-     bfd_vma pc;
-     disassemble_info *info;
+default_print_insn (CGEN_CPU_DESC cd, bfd_vma pc, disassemble_info *info)
 {
-  char buf[CGEN_MAX_INSN_SIZE];
+  bfd_byte buf[CGEN_MAX_INSN_SIZE];
+  int buflen;
   int status;
 
-  /* Read the base part of the insn.  */
+  /* Attempt to read the base part of the insn.  */
+  buflen = cd->base_insn_bitsize / 8;
+  status = (*info->read_memory_func) (pc, buf, buflen, info);
 
-  status = (*info->read_memory_func) (pc, buf, cd->base_insn_bitsize / 8, info);
+  /* Try again with the minimum part, if min < base.  */
+  if (status != 0 && (cd->min_insn_bitsize < cd->base_insn_bitsize))
+    {
+      buflen = cd->min_insn_bitsize / 8;
+      status = (*info->read_memory_func) (pc, buf, buflen, info);
+    }
+
   if (status != 0)
     {
       (*info->memory_error_func) (status, pc, info);
       return -1;
     }
 
-  return print_insn (cd, pc, info, buf, cd->base_insn_bitsize / 8);
+  return print_insn (cd, pc, info, buf, buflen);
 }
 
 /* Main entry point.
    Print one instruction from PC on INFO->STREAM.
    Return the size of the instruction (in bytes).  */
 
-int
-print_insn_nios (pc, info)
-     bfd_vma pc;
-     disassemble_info *info;
+typedef struct cpu_desc_list
 {
+  struct cpu_desc_list *next;
+  CGEN_BITSET *isa;
+  int mach;
+  int endian;
+  CGEN_CPU_DESC cd;
+} cpu_desc_list;
+
+int
+print_insn_nios (bfd_vma pc, disassemble_info *info)
+{
+  static cpu_desc_list *cd_list = 0;
+  cpu_desc_list *cl = 0;
   static CGEN_CPU_DESC cd = 0;
-  static prev_isa,prev_mach,prev_endian;
+  static CGEN_BITSET *prev_isa;
+  static int prev_mach;
+  static int prev_endian;
   int length;
-  int isa,mach;
+  CGEN_BITSET *isa;
+  int mach;
   int endian = (info->endian == BFD_ENDIAN_BIG
 		? CGEN_ENDIAN_BIG
 		: CGEN_ENDIAN_LITTLE);
@@ -650,38 +699,61 @@ print_insn_nios (pc, info)
   arch = info->arch;
   if (arch == bfd_arch_unknown)
     arch = CGEN_BFD_ARCH;
-      
-  /* There's no standard way to compute the isa number (e.g. for arm thumb)
+
+  /* There's no standard way to compute the machine or isa number
      so we leave it to the target.  */
-#ifdef CGEN_COMPUTE_ISA
-  isa = CGEN_COMPUTE_ISA (info);
+#ifdef CGEN_COMPUTE_MACH
+  mach = CGEN_COMPUTE_MACH (info);
 #else
-  isa = 0;
+  mach = info->mach;
 #endif
 
-  mach = info->mach;
+#ifdef CGEN_COMPUTE_ISA
+  {
+    static CGEN_BITSET *permanent_isa;
 
-  /* If we've switched cpu's, close the current table and open a new one.  */
+    if (!permanent_isa)
+      permanent_isa = cgen_bitset_create (MAX_ISAS);
+    isa = permanent_isa;
+    cgen_bitset_clear (isa);
+    cgen_bitset_add (isa, CGEN_COMPUTE_ISA (info));
+  }
+#else
+  isa = info->insn_sets;
+#endif
+
+  /* If we've switched cpu's, try to find a handle we've used before */
   if (cd
-      && (isa != prev_isa
+      && (cgen_bitset_compare (isa, prev_isa) != 0
 	  || mach != prev_mach
 	  || endian != prev_endian))
     {
-      nios_cgen_cpu_close (cd);
       cd = 0;
+      for (cl = cd_list; cl; cl = cl->next)
+	{
+	  if (cgen_bitset_compare (cl->isa, isa) == 0 &&
+	      cl->mach == mach &&
+	      cl->endian == endian)
+	    {
+	      cd = cl->cd;
+ 	      prev_isa = cd->isas;
+	      break;
+	    }
+	}
     }
 
   /* If we haven't initialized yet, initialize the opcode table.  */
   if (! cd)
     {
       const bfd_arch_info_type *arch_type = bfd_lookup_arch (arch, mach);
+      //const bfd_arch_info_type *arch_type = &bfd_nios_arch;
       const char *mach_name;
 
       if (!arch_type)
 	abort ();
       mach_name = arch_type->printable_name;
 
-      prev_isa = isa;
+      prev_isa = cgen_bitset_copy (isa);
       prev_mach = mach;
       prev_endian = endian;
       cd = nios_cgen_cpu_open (CGEN_CPU_OPEN_ISAS, prev_isa,
@@ -690,6 +762,16 @@ print_insn_nios (pc, info)
 				 CGEN_CPU_OPEN_END);
       if (!cd)
 	abort ();
+
+      /* Save this away for future reference.  */
+      cl = xmalloc (sizeof (struct cpu_desc_list));
+      cl->cd = cd;
+      cl->isa = prev_isa;
+      cl->mach = mach;
+      cl->endian = endian;
+      cl->next = cd_list;
+      cd_list = cl;
+
       nios_cgen_init_dis (cd);
     }
 

--- a/libr/asm/arch/nios/gnu/nios-dis.c
+++ b/libr/asm/arch/nios/gnu/nios-dis.c
@@ -1,0 +1,708 @@
+/* Disassembler interface for targets using CGEN. -*- C -*-
+   CGEN: Cpu tools GENerator
+
+THIS FILE IS MACHINE GENERATED WITH CGEN.
+- the resultant file is machine generated, cgen-dis.in isn't
+
+Copyright (C) 1996, 1997, 1998, 1999 Free Software Foundation, Inc.
+
+This file is part of the GNU Binutils and GDB, the GNU debugger.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation, Inc.,
+59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+
+/* ??? Eventually more and more of this stuff can go to cpu-independent files.
+   Keep that in mind.  */
+
+#include "sysdep.h"
+#include <stdio.h>
+#include "ansidecl.h"
+#include "dis-asm.h"
+#include "bfd.h"
+#include "symcat.h"
+#include "nios-desc.h"
+#include "nios-opc.h"
+#include "opintl.h"
+
+/* Default text to print if an instruction isn't recognized.  */
+#define UNKNOWN_INSN_MSG _("*unknown*")
+
+static void print_normal
+     PARAMS ((CGEN_CPU_DESC, PTR, long, unsigned int, bfd_vma, int));
+static void print_address
+     PARAMS ((CGEN_CPU_DESC, PTR, bfd_vma, unsigned int, bfd_vma, int));
+static void print_keyword
+     PARAMS ((CGEN_CPU_DESC, PTR, CGEN_KEYWORD *, long, unsigned int));
+static void print_insn_normal
+     PARAMS ((CGEN_CPU_DESC, PTR, const CGEN_INSN *, CGEN_FIELDS *,
+	      bfd_vma, int));
+static int print_insn PARAMS ((CGEN_CPU_DESC, bfd_vma,
+			       disassemble_info *, char *, int));
+static int default_print_insn
+     PARAMS ((CGEN_CPU_DESC, bfd_vma, disassemble_info *));
+
+/* -- disassembler routines inserted here */
+
+/* -- dis.c */
+
+/* Include "%hi(foo) in output.  */
+      
+static void
+print_Rbi5 (cd, dis_info, value, attrs, pc, length)
+     CGEN_CPU_DESC cd;
+     PTR dis_info;
+     long value;
+     unsigned int attrs;
+     bfd_vma pc;
+     int length;
+{
+  int status;
+  char buf[2];
+  unsigned long insn_value;
+  const CGEN_INSN_LIST *insn_list;
+
+  disassemble_info *info = (disassemble_info *) dis_info;
+
+  /* look at previous instruction, if possible, to see if it is PFX */
+  if (pc > 0)
+    {
+      status = (*info->read_memory_func) (pc - 2, buf, 2, info);  
+      if (status != 0)
+	{
+	  print_keyword (cd, info, & nios_cgen_opval_gr_names, value, 0);
+	  return;
+	}
+      insn_value = info->endian == BFD_ENDIAN_BIG ? bfd_getb16 (buf) : bfd_getl16 (buf);
+      insn_list = CGEN_DIS_LOOKUP_INSN (cd, buf, insn_value);
+      while (insn_list != NULL)
+	{
+	  const CGEN_INSN *insn = insn_list->insn;
+
+	  /* Basic bit mask must be correct.  */
+	  /* ??? May wish to allow target to defer this check until the extract
+	     handler.  */
+	  if ((insn_value & CGEN_INSN_BASE_MASK (insn))
+	      == CGEN_INSN_BASE_VALUE (insn))
+	    {
+	      if (CGEN_INSN_ATTR_VALUE (insn, CGEN_INSN_PREFIX))
+		(*info->fprintf_func) (info->stream, "0x%x", value);
+	      else
+		print_keyword (cd, info, & nios_cgen_opval_gr_names, value, 0);
+	      return;
+	    }
+	  insn_list = CGEN_DIS_NEXT_INSN (insn_list);
+	}
+    }
+  print_keyword (cd, info, & nios_cgen_opval_gr_names, value, 0);
+}
+
+static void
+print_i11 (cd, dis_info, value, attrs, pc, length)
+     CGEN_CPU_DESC cd;
+     PTR dis_info;
+     long value;
+     unsigned int attrs;
+     bfd_vma pc;
+     int length;
+{
+  disassemble_info *info = (disassemble_info *) dis_info;
+  (*info->fprintf_func) (info->stream, "%%hi(0x%lx)", value << 5);
+}
+
+static void
+print_r0 (cd, dis_info, value, attrs, pc, length)
+     CGEN_CPU_DESC cd;
+     PTR dis_info;
+     long value;
+     unsigned int attrs;
+     bfd_vma pc;
+     int length;
+{
+  disassemble_info *info = (disassemble_info *) dis_info;
+  (*info->fprintf_func) (info->stream, "%g0");
+}
+
+static void
+print_i16 (cd, dis_info, value, attrs, pc, length)
+     CGEN_CPU_DESC cd;
+     PTR dis_info;
+     long value;
+     unsigned int attrs;
+     bfd_vma pc;
+     int length;
+{
+  disassemble_info *info = (disassemble_info *) dis_info;
+  (*info->fprintf_func) (info->stream, "#0x%hx)", (short)value);
+}
+
+static void
+print_i32 (cd, dis_info, value, attrs, pc, length)
+     CGEN_CPU_DESC cd;
+     PTR dis_info;
+     long value;
+     unsigned int attrs;
+     bfd_vma pc;
+     int length;
+{
+  disassemble_info *info = (disassemble_info *) dis_info;
+  (*info->fprintf_func) (info->stream, "#0x%lx)", value);
+}
+
+static void
+print_i4w (cd, dis_info, value, attrs, pc, length)
+     CGEN_CPU_DESC cd;
+     PTR dis_info;
+     long value;
+     unsigned int attrs;
+     bfd_vma pc;
+     int length;
+{
+  char *str;
+  disassemble_info *info = (disassemble_info *) dis_info;
+  switch (value)
+    {
+    case CC_Z:
+      str = "cc_eq";
+      break;
+    case CC_NZ:
+      str = "cc_ne";
+      break;
+    case CC_C:
+      str = "cc_c";
+      break;
+    case CC_NC:
+      str = "cc_nc";
+      break;
+    case CC_V:
+      str = "cc_v";
+      break;
+    case CC_NV:
+      str = "cc_nv";
+      break;
+    case CC_GT:
+      str = "cc_gt";
+      break;
+    case CC_GE:
+      str = "cc_ge";
+      break;
+    case CC_LT:
+      str = "cc_lt";
+      break;
+    case CC_LE:
+      str = "cc_le";
+      break;
+    case CC_LS:
+      str = "cc_ls";
+      break;
+    case CC_HI:
+      str = "cc_hi";
+      break;
+    case CC_PL:
+      str = "cc_pl";
+      break;
+    case CC_MI:
+      str = "cc_mi";
+      break;
+    }
+
+  if (str != NULL)
+    (*info->fprintf_func) (info->stream, "%s", str);
+  else
+    (*info->fprintf_func) (info->stream, "0x%x", value);
+}
+
+/* -- */
+
+/* Main entry point for printing operands.
+   XINFO is a `void *' and not a `disassemble_info *' to not put a requirement
+   of dis-asm.h on cgen.h.
+
+   This function is basically just a big switch statement.  Earlier versions
+   used tables to look up the function to use, but
+   - if the table contains both assembler and disassembler functions then
+     the disassembler contains much of the assembler and vice-versa,
+   - there's a lot of inlining possibilities as things grow,
+   - using a switch statement avoids the function call overhead.
+
+   This function could be moved into `print_insn_normal', but keeping it
+   separate makes clear the interface between `print_insn_normal' and each of
+   the handlers.
+*/
+
+void
+nios_cgen_print_operand (cd, opindex, xinfo, fields, attrs, pc, length)
+     CGEN_CPU_DESC cd;
+     int opindex;
+     PTR xinfo;
+     CGEN_FIELDS *fields;
+     void const *attrs;
+     bfd_vma pc;
+     int length;
+{
+ disassemble_info *info = (disassemble_info *) xinfo;
+
+  switch (opindex)
+    {
+    case NIOS_OPERAND_CTLC :
+      print_normal (cd, info, fields->f_CTLc, 0|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_RBI5 :
+      print_Rbi5 (cd, info, fields->f_Rbi5, 0, pc, length);
+      break;
+    case NIOS_OPERAND_BSRR_REL6 :
+      print_address (cd, info, fields->f_bsrr_i6_rel, 0|(1<<CGEN_OPERAND_RELAX)|(1<<CGEN_OPERAND_PCREL_ADDR), pc, length);
+      break;
+    case NIOS_OPERAND_I1 :
+      print_normal (cd, info, fields->f_i1, 0|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_I10 :
+      print_normal (cd, info, fields->f_i10, 0|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_I11 :
+      print_i11 (cd, info, fields->f_i11, 0|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_I2 :
+      print_normal (cd, info, fields->f_i2, 0|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_I4W :
+      print_i4w (cd, info, fields->f_i4w, 0|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_I4WN :
+      print_i4w (cd, info, fields->f_i4w, 0|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_I5 :
+      print_normal (cd, info, fields->f_i5, 0|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_I6V :
+      print_normal (cd, info, fields->f_i6v, 0|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_I8 :
+      print_normal (cd, info, fields->f_i8, 0|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_I8V :
+      print_normal (cd, info, fields->f_i8v, 0|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_I9 :
+      print_normal (cd, info, fields->f_i9, 0|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_M16_R0 :
+      print_keyword (cd, info, & nios_cgen_opval_h_m16_gr0, 0, 0);
+      break;
+    case NIOS_OPERAND_M16_RA :
+      print_keyword (cd, info, & nios_cgen_opval_gr_names, fields->f_Ra, 0);
+      break;
+    case NIOS_OPERAND_M16_RB :
+      print_keyword (cd, info, & nios_cgen_opval_gr_names, fields->f_Rb, 0);
+      break;
+    case NIOS_OPERAND_M16_RP :
+      print_keyword (cd, info, & nios_cgen_opval_bp_names, fields->f_Rp, 0);
+      break;
+    case NIOS_OPERAND_M16_RZ :
+      print_keyword (cd, info, & nios_cgen_opval_gr_names, fields->f_Rz, 0);
+      break;
+    case NIOS_OPERAND_M16_I6 :
+      print_address (cd, info, fields->f_i6_rel_h, 0|(1<<CGEN_OPERAND_PCREL_ADDR), pc, length);
+      break;
+    case NIOS_OPERAND_M16_I8V :
+      print_address (cd, info, fields->f_i8v_rel_h, 0|(1<<CGEN_OPERAND_PCREL_ADDR), pc, length);
+      break;
+    case NIOS_OPERAND_M16_SP :
+      print_keyword (cd, info, & nios_cgen_opval_h_m16_sp, 0, 0);
+      break;
+    case NIOS_OPERAND_M32_R0 :
+      print_keyword (cd, info, & nios_cgen_opval_gr0_name, 0, 0);
+      break;
+    case NIOS_OPERAND_M32_RA :
+      print_keyword (cd, info, & nios_cgen_opval_gr_names, fields->f_Ra, 0);
+      break;
+    case NIOS_OPERAND_M32_RB :
+      print_keyword (cd, info, & nios_cgen_opval_gr_names, fields->f_Rb, 0);
+      break;
+    case NIOS_OPERAND_M32_RP :
+      print_keyword (cd, info, & nios_cgen_opval_bp_names, fields->f_Rp, 0);
+      break;
+    case NIOS_OPERAND_M32_RZ :
+      print_keyword (cd, info, & nios_cgen_opval_gr_names, fields->f_Rz, 0);
+      break;
+    case NIOS_OPERAND_M32_I6 :
+      print_address (cd, info, fields->f_i6_rel_w, 0|(1<<CGEN_OPERAND_PCREL_ADDR), pc, length);
+      break;
+    case NIOS_OPERAND_M32_I8V :
+      print_address (cd, info, fields->f_i8v_rel_w, 0|(1<<CGEN_OPERAND_PCREL_ADDR), pc, length);
+      break;
+    case NIOS_OPERAND_M32_SP :
+      print_keyword (cd, info, & nios_cgen_opval_h_m32_sp, 0, 0);
+      break;
+    case NIOS_OPERAND_O1 :
+      print_normal (cd, info, fields->f_o1, 0, pc, length);
+      break;
+    case NIOS_OPERAND_O2 :
+      print_normal (cd, info, fields->f_o2, 0, pc, length);
+      break;
+    case NIOS_OPERAND_REL11 :
+      print_address (cd, info, fields->f_i11_rel, 0|(1<<CGEN_OPERAND_PCREL_ADDR), pc, length);
+      break;
+    case NIOS_OPERAND_SAVE_I8V :
+      print_normal (cd, info, fields->f_i8v, 0|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_SI11 :
+      print_normal (cd, info, fields->f_i11, 0|(1<<CGEN_OPERAND_SIGNED)|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_SI5 :
+      print_normal (cd, info, fields->f_i5, 0|(1<<CGEN_OPERAND_SIGNED)|(1<<CGEN_OPERAND_HASH_PREFIX), pc, length);
+      break;
+    case NIOS_OPERAND_X1 :
+      print_normal (cd, info, fields->f_x1, 0, pc, length);
+      break;
+    case NIOS_OPERAND_XRA :
+      print_normal (cd, info, fields->f_Ra, 0, pc, length);
+      break;
+
+    default :
+      /* xgettext:c-format */
+      fprintf (stderr, _("Unrecognized field %d while printing insn.\n"),
+	       opindex);
+    abort ();
+  }
+}
+
+cgen_print_fn * const nios_cgen_print_handlers[] = 
+{
+  print_insn_normal,
+};
+
+
+void
+nios_cgen_init_dis (cd)
+     CGEN_CPU_DESC cd;
+{
+  nios_cgen_init_opcode_table (cd);
+  nios_cgen_init_ibld_table (cd);
+  cd->print_handlers = & nios_cgen_print_handlers[0];
+  cd->print_operand = nios_cgen_print_operand;
+}
+
+
+/* Default print handler.  */
+
+static void
+print_normal (cd, dis_info, value, attrs, pc, length)
+     CGEN_CPU_DESC cd;
+     PTR dis_info;
+     long value;
+     unsigned int attrs;
+     bfd_vma pc;
+     int length;
+{
+  disassemble_info *info = (disassemble_info *) dis_info;
+
+#ifdef CGEN_PRINT_NORMAL
+  CGEN_PRINT_NORMAL (cd, info, value, attrs, pc, length);
+#endif
+
+  /* Print the operand as directed by the attributes.  */
+  if (CGEN_BOOL_ATTR (attrs, CGEN_OPERAND_SEM_ONLY))
+    ; /* nothing to do */
+  else if (CGEN_BOOL_ATTR (attrs, CGEN_OPERAND_SIGNED))
+    (*info->fprintf_func) (info->stream, "%ld", value);
+  else
+    (*info->fprintf_func) (info->stream, "0x%lx", value);
+}
+
+/* Default address handler.  */
+
+static void
+print_address (cd, dis_info, value, attrs, pc, length)
+     CGEN_CPU_DESC cd;
+     PTR dis_info;
+     bfd_vma value;
+     unsigned int attrs;
+     bfd_vma pc;
+     int length;
+{
+  disassemble_info *info = (disassemble_info *) dis_info;
+
+#ifdef CGEN_PRINT_ADDRESS
+  CGEN_PRINT_ADDRESS (cd, info, value, attrs, pc, length);
+#endif
+
+  /* Print the operand as directed by the attributes.  */
+  if (CGEN_BOOL_ATTR (attrs, CGEN_OPERAND_SEM_ONLY))
+    ; /* nothing to do */
+  else if (CGEN_BOOL_ATTR (attrs, CGEN_OPERAND_PCREL_ADDR))
+    (*info->print_address_func) (value, info);
+  else if (CGEN_BOOL_ATTR (attrs, CGEN_OPERAND_ABS_ADDR))
+    (*info->print_address_func) (value, info);
+  else if (CGEN_BOOL_ATTR (attrs, CGEN_OPERAND_SIGNED))
+    (*info->fprintf_func) (info->stream, "%ld", (long) value);
+  else
+    (*info->fprintf_func) (info->stream, "0x%lx", (long) value);
+}
+
+/* Keyword print handler.  */
+
+static void
+print_keyword (cd, dis_info, keyword_table, value, attrs)
+     CGEN_CPU_DESC cd;
+     PTR dis_info;
+     CGEN_KEYWORD *keyword_table;
+     long value;
+     unsigned int attrs;
+{
+  disassemble_info *info = (disassemble_info *) dis_info;
+  const CGEN_KEYWORD_ENTRY *ke;
+
+  ke = cgen_keyword_lookup_value (keyword_table, value);
+  if (ke != NULL)
+    (*info->fprintf_func) (info->stream, "%s", ke->name);
+  else
+    (*info->fprintf_func) (info->stream, "???");
+}
+
+/* Default insn printer.
+
+   DIS_INFO is defined as `PTR' so the disassembler needn't know anything
+   about disassemble_info.  */
+
+static void
+print_insn_normal (cd, dis_info, insn, fields, pc, length)
+     CGEN_CPU_DESC cd;
+     PTR dis_info;
+     const CGEN_INSN *insn;
+     CGEN_FIELDS *fields;
+     bfd_vma pc;
+     int length;
+{
+  const CGEN_SYNTAX *syntax = CGEN_INSN_SYNTAX (insn);
+  disassemble_info *info = (disassemble_info *) dis_info;
+  const unsigned char *syn;
+
+  CGEN_INIT_PRINT (cd);
+
+  for (syn = CGEN_SYNTAX_STRING (syntax); *syn; ++syn)
+    {
+      if (CGEN_SYNTAX_MNEMONIC_P (*syn))
+	{
+	  (*info->fprintf_func) (info->stream, "%s", CGEN_INSN_MNEMONIC (insn));
+	  continue;
+	}
+      if (CGEN_SYNTAX_CHAR_P (*syn))
+	{
+	  (*info->fprintf_func) (info->stream, "%c", CGEN_SYNTAX_CHAR (*syn));
+	  continue;
+	}
+
+      /* We have an operand.  */
+      nios_cgen_print_operand (cd, CGEN_SYNTAX_FIELD (*syn), info,
+				 fields, CGEN_INSN_ATTRS (insn), pc, length);
+    }
+}
+
+/* Utility to print an insn.
+   BUF is the base part of the insn, target byte order, BUFLEN bytes long.
+   The result is the size of the insn in bytes or zero for an unknown insn
+   or -1 if an error occurs fetching data (memory_error_func will have
+   been called).  */
+
+static int
+print_insn (cd, pc, info, buf, buflen)
+     CGEN_CPU_DESC cd;
+     bfd_vma pc;
+     disassemble_info *info;
+     char *buf;
+     int buflen;
+{
+  unsigned long insn_value;
+  const CGEN_INSN_LIST *insn_list;
+  CGEN_EXTRACT_INFO ex_info;
+
+  ex_info.dis_info = info;
+  ex_info.valid = (1 << (cd->base_insn_bitsize / 8)) - 1;
+  ex_info.insn_bytes = buf;
+
+  switch (buflen)
+    {
+    case 1:
+      insn_value = buf[0];
+      break;
+    case 2:
+      insn_value = info->endian == BFD_ENDIAN_BIG ? bfd_getb16 (buf) : bfd_getl16 (buf);
+      break;
+    case 4:
+      insn_value = info->endian == BFD_ENDIAN_BIG ? bfd_getb32 (buf) : bfd_getl32 (buf);
+      break;
+    default:
+      abort ();
+    }
+
+  /* The instructions are stored in hash lists.
+     Pick the first one and keep trying until we find the right one.  */
+
+  insn_list = CGEN_DIS_LOOKUP_INSN (cd, buf, insn_value);
+  while (insn_list != NULL)
+    {
+      const CGEN_INSN *insn = insn_list->insn;
+      CGEN_FIELDS fields;
+      int length;
+
+#ifdef CGEN_VALIDATE_INSN_SUPPORTED 
+      /* not needed as insn shouldn't be in hash lists if not supported */
+      /* Supported by this cpu?  */
+      if (! nios_cgen_insn_supported (cd, insn))
+        {
+          insn_list = CGEN_DIS_NEXT_INSN (insn_list);
+	  continue;
+        }
+#endif
+
+      /* Basic bit mask must be correct.  */
+      /* ??? May wish to allow target to defer this check until the extract
+	 handler.  */
+      if ((insn_value & CGEN_INSN_BASE_MASK (insn))
+	  == CGEN_INSN_BASE_VALUE (insn))
+	{
+	  /* Printing is handled in two passes.  The first pass parses the
+	     machine insn and extracts the fields.  The second pass prints
+	     them.  */
+
+	  length = CGEN_EXTRACT_FN (cd, insn)
+	    (cd, insn, &ex_info, insn_value, &fields, pc);
+	  /* length < 0 -> error */
+	  if (length < 0)
+	    return length;
+	  if (length > 0)
+	    {
+	      CGEN_PRINT_FN (cd, insn) (cd, info, insn, &fields, pc, length);
+	      /* length is in bits, result is in bytes */
+	      return length / 8;
+	    }
+	}
+
+      insn_list = CGEN_DIS_NEXT_INSN (insn_list);
+    }
+
+  return 0;
+}
+
+/* Default value for CGEN_PRINT_INSN.
+   The result is the size of the insn in bytes or zero for an unknown insn
+   or -1 if an error occured fetching bytes.  */
+
+#ifndef CGEN_PRINT_INSN
+#define CGEN_PRINT_INSN default_print_insn
+#endif
+
+static int
+default_print_insn (cd, pc, info)
+     CGEN_CPU_DESC cd;
+     bfd_vma pc;
+     disassemble_info *info;
+{
+  char buf[CGEN_MAX_INSN_SIZE];
+  int status;
+
+  /* Read the base part of the insn.  */
+
+  status = (*info->read_memory_func) (pc, buf, cd->base_insn_bitsize / 8, info);
+  if (status != 0)
+    {
+      (*info->memory_error_func) (status, pc, info);
+      return -1;
+    }
+
+  return print_insn (cd, pc, info, buf, cd->base_insn_bitsize / 8);
+}
+
+/* Main entry point.
+   Print one instruction from PC on INFO->STREAM.
+   Return the size of the instruction (in bytes).  */
+
+int
+print_insn_nios (pc, info)
+     bfd_vma pc;
+     disassemble_info *info;
+{
+  static CGEN_CPU_DESC cd = 0;
+  static prev_isa,prev_mach,prev_endian;
+  int length;
+  int isa,mach;
+  int endian = (info->endian == BFD_ENDIAN_BIG
+		? CGEN_ENDIAN_BIG
+		: CGEN_ENDIAN_LITTLE);
+  enum bfd_architecture arch;
+
+  /* ??? gdb will set mach but leave the architecture as "unknown" */
+#ifndef CGEN_BFD_ARCH
+#define CGEN_BFD_ARCH bfd_arch_nios
+#endif
+  arch = info->arch;
+  if (arch == bfd_arch_unknown)
+    arch = CGEN_BFD_ARCH;
+      
+  /* There's no standard way to compute the isa number (e.g. for arm thumb)
+     so we leave it to the target.  */
+#ifdef CGEN_COMPUTE_ISA
+  isa = CGEN_COMPUTE_ISA (info);
+#else
+  isa = 0;
+#endif
+
+  mach = info->mach;
+
+  /* If we've switched cpu's, close the current table and open a new one.  */
+  if (cd
+      && (isa != prev_isa
+	  || mach != prev_mach
+	  || endian != prev_endian))
+    {
+      nios_cgen_cpu_close (cd);
+      cd = 0;
+    }
+
+  /* If we haven't initialized yet, initialize the opcode table.  */
+  if (! cd)
+    {
+      const bfd_arch_info_type *arch_type = bfd_lookup_arch (arch, mach);
+      const char *mach_name;
+
+      if (!arch_type)
+	abort ();
+      mach_name = arch_type->printable_name;
+
+      prev_isa = isa;
+      prev_mach = mach;
+      prev_endian = endian;
+      cd = nios_cgen_cpu_open (CGEN_CPU_OPEN_ISAS, prev_isa,
+				 CGEN_CPU_OPEN_BFDMACH, mach_name,
+				 CGEN_CPU_OPEN_ENDIAN, prev_endian,
+				 CGEN_CPU_OPEN_END);
+      if (!cd)
+	abort ();
+      nios_cgen_init_dis (cd);
+    }
+
+  /* We try to have as much common code as possible.
+     But at this point some targets need to take over.  */
+  /* ??? Some targets may need a hook elsewhere.  Try to avoid this,
+     but if not possible try to move this hook elsewhere rather than
+     have two hooks.  */
+  length = CGEN_PRINT_INSN (cd, pc, info);
+  if (length > 0)
+    return length;
+  if (length < 0)
+    return -1;
+
+  (*info->fprintf_func) (info->stream, UNKNOWN_INSN_MSG);
+  return cd->default_insn_bitsize / 8;
+}

--- a/libr/asm/arch/nios/gnu/nios-dis.c
+++ b/libr/asm/arch/nios/gnu/nios-dis.c
@@ -29,7 +29,8 @@ along with this program; if not, write to the Free Software Foundation, Inc.,
 #include <stdio.h>
 #include "ansidecl.h"
 #include "dis-asm.h"
-#include "bfd.h"
+//#include "bfd.h"
+#include "mybfd.h"
 #include "symcat.h"
 #include "nios-desc.h"
 #include "nios-opc.h"

--- a/libr/asm/arch/nios/gnu/nios-ibld.c
+++ b/libr/asm/arch/nios/gnu/nios-ibld.c
@@ -1,0 +1,1490 @@
+/* Instruction building/extraction support for nios. -*- C -*-
+
+THIS FILE IS MACHINE GENERATED WITH CGEN: Cpu tools GENerator.
+- the resultant file is machine generated, cgen-ibld.in isn't
+
+Copyright (C) 1996, 1997, 1998, 1999, 2000 Free Software Foundation, Inc.
+
+This file is part of the GNU Binutils and GDB, the GNU debugger.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation, Inc.,
+59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+
+/* ??? Eventually more and more of this stuff can go to cpu-independent files.
+   Keep that in mind.  */
+
+#include "sysdep.h"
+#include <ctype.h>
+#include <stdio.h>
+#include "ansidecl.h"
+#include "dis-asm.h"
+#include "bfd.h"
+#include "symcat.h"
+#include "nios-desc.h"
+#include "nios-opc.h"
+#include "opintl.h"
+
+#undef min
+#define min(a,b) ((a) < (b) ? (a) : (b))
+#undef max
+#define max(a,b) ((a) > (b) ? (a) : (b))
+
+/* Used by the ifield rtx function.  */
+#define FLD(f) (fields->f)
+
+static const char * insert_normal
+     PARAMS ((CGEN_CPU_DESC, long, unsigned int, unsigned int, unsigned int,
+	      unsigned int, unsigned int, unsigned int, CGEN_INSN_BYTES_PTR));
+static const char * insert_insn_normal
+     PARAMS ((CGEN_CPU_DESC, const CGEN_INSN *,
+	      CGEN_FIELDS *, CGEN_INSN_BYTES_PTR, bfd_vma));
+
+static int extract_normal
+     PARAMS ((CGEN_CPU_DESC, CGEN_EXTRACT_INFO *, CGEN_INSN_INT,
+	      unsigned int, unsigned int, unsigned int, unsigned int,
+	      unsigned int, unsigned int, bfd_vma, long *));
+static int extract_insn_normal
+     PARAMS ((CGEN_CPU_DESC, const CGEN_INSN *, CGEN_EXTRACT_INFO *,
+	      CGEN_INSN_INT, CGEN_FIELDS *, bfd_vma));
+
+/* Operand insertion.  */
+
+#if ! CGEN_INT_INSN_P
+
+/* Subroutine of insert_normal.  */
+
+static CGEN_INLINE void
+insert_1 (cd, value, start, length, word_length, bufp)
+     CGEN_CPU_DESC cd;
+     unsigned long value;
+     int start,length,word_length;
+     unsigned char *bufp;
+{
+  unsigned long x,mask;
+  int shift;
+  int big_p = CGEN_CPU_INSN_ENDIAN (cd) == CGEN_ENDIAN_BIG;
+
+  switch (word_length)
+    {
+    case 8:
+      x = *bufp;
+      break;
+    case 16:
+      if (big_p)
+	x = bfd_getb16 (bufp);
+      else
+	x = bfd_getl16 (bufp);
+      break;
+    case 24:
+      /* ??? This may need reworking as these cases don't necessarily
+	 want the first byte and the last two bytes handled like this.  */
+      if (big_p)
+	x = (bufp[0] << 16) | bfd_getb16 (bufp + 1);
+      else
+	x = bfd_getl16 (bufp) | (bufp[2] << 16);
+      break;
+    case 32:
+      if (big_p)
+	x = bfd_getb32 (bufp);
+      else
+	x = bfd_getl32 (bufp);
+      break;
+    default :
+      abort ();
+    }
+
+  /* Written this way to avoid undefined behaviour.  */
+  mask = (((1L << (length - 1)) - 1) << 1) | 1;
+  if (CGEN_INSN_LSB0_P)
+    shift = (start + 1) - length;
+  else
+    shift = (word_length - (start + length));
+  x = (x & ~(mask << shift)) | ((value & mask) << shift);
+
+  switch (word_length)
+    {
+    case 8:
+      *bufp = x;
+      break;
+    case 16:
+      if (big_p)
+	bfd_putb16 (x, bufp);
+      else
+	bfd_putl16 (x, bufp);
+      break;
+    case 24:
+      /* ??? This may need reworking as these cases don't necessarily
+	 want the first byte and the last two bytes handled like this.  */
+      if (big_p)
+	{
+	  bufp[0] = x >> 16;
+	  bfd_putb16 (x, bufp + 1);
+	}
+      else
+	{
+	  bfd_putl16 (x, bufp);
+	  bufp[2] = x >> 16;
+	}
+      break;
+    case 32:
+      if (big_p)
+	bfd_putb32 (x, bufp);
+      else
+	bfd_putl32 (x, bufp);
+      break;
+    default :
+      abort ();
+    }
+}
+
+#endif /* ! CGEN_INT_INSN_P */
+
+/* Default insertion routine.
+
+   ATTRS is a mask of the boolean attributes.
+   WORD_OFFSET is the offset in bits from the start of the insn of the value.
+   WORD_LENGTH is the length of the word in bits in which the value resides.
+   START is the starting bit number in the word, architecture origin.
+   LENGTH is the length of VALUE in bits.
+   TOTAL_LENGTH is the total length of the insn in bits.
+
+   The result is an error message or NULL if success.  */
+
+/* ??? This duplicates functionality with bfd's howto table and
+   bfd_install_relocation.  */
+/* ??? This doesn't handle bfd_vma's.  Create another function when
+   necessary.  */
+
+static const char *
+insert_normal (cd, value, attrs, word_offset, start, length, word_length,
+	       total_length, buffer)
+     CGEN_CPU_DESC cd;
+     long value;
+     unsigned int attrs;
+     unsigned int word_offset, start, length, word_length, total_length;
+     CGEN_INSN_BYTES_PTR buffer;
+{
+  static char errbuf[100];
+  /* Written this way to avoid undefined behaviour.  */
+  unsigned long mask = (((1L << (length - 1)) - 1) << 1) | 1;
+
+  /* If LENGTH is zero, this operand doesn't contribute to the value.  */
+  if (length == 0)
+    return NULL;
+
+  if (CGEN_INT_INSN_P
+      && word_offset != 0)
+    abort ();
+
+  if (word_length > 32)
+    abort ();
+
+  /* For architectures with insns smaller than the base-insn-bitsize,
+     word_length may be too big.  */
+  if (cd->min_insn_bitsize < cd->base_insn_bitsize)
+    {
+      if (word_offset == 0
+	  && word_length > total_length)
+	word_length = total_length;
+    }
+
+  /* Ensure VALUE will fit.  */
+  if (! CGEN_BOOL_ATTR (attrs, CGEN_IFLD_SIGNED))
+    {
+      unsigned long maxval = mask;
+      
+      if ((unsigned long) value > maxval)
+	{
+	  /* xgettext:c-format */
+	  sprintf (errbuf,
+		   _("operand out of range (%lu not between 0 and %lu)"),
+		   value, maxval);
+	  return errbuf;
+	}
+    }
+  else
+    {
+      if (! cgen_signed_overflow_ok_p (cd))
+	{
+	  long minval = - (1L << (length - 1));
+	  long maxval =   (1L << (length - 1)) - 1;
+	  
+	  if (value < minval || value > maxval)
+	    {
+	      sprintf
+		/* xgettext:c-format */
+		(errbuf, _("operand out of range (%ld not between %ld and %ld)"),
+		 value, minval, maxval);
+	      return errbuf;
+	    }
+	}
+    }
+
+#if CGEN_INT_INSN_P
+
+  {
+    int shift;
+
+    if (CGEN_INSN_LSB0_P)
+      shift = (start + 1) - length;
+    else
+      shift = word_length - (start + length);
+    *buffer = (*buffer & ~(mask << shift)) | ((value & mask) << shift);
+  }
+
+#else /* ! CGEN_INT_INSN_P */
+
+  {
+    unsigned char *bufp = (unsigned char *) buffer + word_offset / 8;
+
+    insert_1 (cd, value, start, length, word_length, bufp);
+  }
+
+#endif /* ! CGEN_INT_INSN_P */
+
+  return NULL;
+}
+
+/* Default insn builder (insert handler).
+   The instruction is recorded in CGEN_INT_INSN_P byte order
+   (meaning that if CGEN_INT_INSN_P BUFFER is an int * and thus the value is
+   recorded in host byte order, otherwise BUFFER is an array of bytes and the
+   value is recorded in target byte order).
+   The result is an error message or NULL if success.  */
+
+static const char *
+insert_insn_normal (cd, insn, fields, buffer, pc)
+     CGEN_CPU_DESC cd;
+     const CGEN_INSN * insn;
+     CGEN_FIELDS * fields;
+     CGEN_INSN_BYTES_PTR buffer;
+     bfd_vma pc;
+{
+  const CGEN_SYNTAX *syntax = CGEN_INSN_SYNTAX (insn);
+  unsigned long value;
+  const unsigned char * syn;
+
+  CGEN_INIT_INSERT (cd);
+  value = CGEN_INSN_BASE_VALUE (insn);
+
+  /* If we're recording insns as numbers (rather than a string of bytes),
+     target byte order handling is deferred until later.  */
+
+#if CGEN_INT_INSN_P
+
+  *buffer = value;
+
+#else
+
+  cgen_put_insn_value (cd, buffer, min (cd->base_insn_bitsize,
+					CGEN_FIELDS_BITSIZE (fields)),
+		       value);
+
+#endif /* ! CGEN_INT_INSN_P */
+
+  /* ??? It would be better to scan the format's fields.
+     Still need to be able to insert a value based on the operand though;
+     e.g. storing a branch displacement that got resolved later.
+     Needs more thought first.  */
+
+  for (syn = CGEN_SYNTAX_STRING (syntax); * syn != '\0'; ++ syn)
+    {
+      const char *errmsg;
+
+      if (CGEN_SYNTAX_CHAR_P (* syn))
+	continue;
+
+      errmsg = (* cd->insert_operand) (cd, CGEN_SYNTAX_FIELD (*syn),
+				       fields, buffer, pc);
+      if (errmsg)
+	return errmsg;
+    }
+
+  return NULL;
+}
+
+/* Operand extraction.  */
+
+#if ! CGEN_INT_INSN_P
+
+/* Subroutine of extract_normal.
+   Ensure sufficient bytes are cached in EX_INFO.
+   OFFSET is the offset in bytes from the start of the insn of the value.
+   BYTES is the length of the needed value.
+   Returns 1 for success, 0 for failure.  */
+
+static CGEN_INLINE int
+fill_cache (cd, ex_info, offset, bytes, pc)
+     CGEN_CPU_DESC cd;
+     CGEN_EXTRACT_INFO *ex_info;
+     int offset, bytes;
+     bfd_vma pc;
+{
+  /* It's doubtful that the middle part has already been fetched so
+     we don't optimize that case.  kiss.  */
+  int mask;
+  disassemble_info *info = (disassemble_info *) ex_info->dis_info;
+
+  /* First do a quick check.  */
+  mask = (1 << bytes) - 1;
+  if (((ex_info->valid >> offset) & mask) == mask)
+    return 1;
+
+  /* Search for the first byte we need to read.  */
+  for (mask = 1 << offset; bytes > 0; --bytes, ++offset, mask <<= 1)
+    if (! (mask & ex_info->valid))
+      break;
+
+  if (bytes)
+    {
+      int status;
+
+      pc += offset;
+      status = (*info->read_memory_func)
+	(pc, ex_info->insn_bytes + offset, bytes, info);
+
+      if (status != 0)
+	{
+	  (*info->memory_error_func) (status, pc, info);
+	  return 0;
+	}
+
+      ex_info->valid |= ((1 << bytes) - 1) << offset;
+    }
+
+  return 1;
+}
+
+/* Subroutine of extract_normal.  */
+
+static CGEN_INLINE long
+extract_1 (cd, ex_info, start, length, word_length, bufp, pc)
+     CGEN_CPU_DESC cd;
+     CGEN_EXTRACT_INFO *ex_info;
+     int start,length,word_length;
+     unsigned char *bufp;
+     bfd_vma pc;
+{
+  unsigned long x,mask;
+  int shift;
+  int big_p = CGEN_CPU_INSN_ENDIAN (cd) == CGEN_ENDIAN_BIG;
+
+  switch (word_length)
+    {
+    case 8:
+      x = *bufp;
+      break;
+    case 16:
+      if (big_p)
+	x = bfd_getb16 (bufp);
+      else
+	x = bfd_getl16 (bufp);
+      break;
+    case 24:
+      /* ??? This may need reworking as these cases don't necessarily
+	 want the first byte and the last two bytes handled like this.  */
+      if (big_p)
+	x = (bufp[0] << 16) | bfd_getb16 (bufp + 1);
+      else
+	x = bfd_getl16 (bufp) | (bufp[2] << 16);
+      break;
+    case 32:
+      if (big_p)
+	x = bfd_getb32 (bufp);
+      else
+	x = bfd_getl32 (bufp);
+      break;
+    default :
+      abort ();
+    }
+
+  /* Written this way to avoid undefined behaviour.  */
+  mask = (((1L << (length - 1)) - 1) << 1) | 1;
+  if (CGEN_INSN_LSB0_P)
+    shift = (start + 1) - length;
+  else
+    shift = (word_length - (start + length));
+  return (x >> shift) & mask;
+}
+
+#endif /* ! CGEN_INT_INSN_P */
+
+/* Default extraction routine.
+
+   INSN_VALUE is the first base_insn_bitsize bits of the insn in host order,
+   or sometimes less for cases like the m32r where the base insn size is 32
+   but some insns are 16 bits.
+   ATTRS is a mask of the boolean attributes.  We only need `SIGNED',
+   but for generality we take a bitmask of all of them.
+   WORD_OFFSET is the offset in bits from the start of the insn of the value.
+   WORD_LENGTH is the length of the word in bits in which the value resides.
+   START is the starting bit number in the word, architecture origin.
+   LENGTH is the length of VALUE in bits.
+   TOTAL_LENGTH is the total length of the insn in bits.
+
+   Returns 1 for success, 0 for failure.  */
+
+/* ??? The return code isn't properly used.  wip.  */
+
+/* ??? This doesn't handle bfd_vma's.  Create another function when
+   necessary.  */
+
+static int
+extract_normal (cd, ex_info, insn_value, attrs, word_offset, start, length,
+		word_length, total_length, pc, valuep)
+     CGEN_CPU_DESC cd;
+     CGEN_EXTRACT_INFO *ex_info;
+     CGEN_INSN_INT insn_value;
+     unsigned int attrs;
+     unsigned int word_offset, start, length, word_length, total_length;
+     bfd_vma pc;
+     long *valuep;
+{
+  CGEN_INSN_INT value;
+
+  /* If LENGTH is zero, this operand doesn't contribute to the value
+     so give it a standard value of zero.  */
+  if (length == 0)
+    {
+      *valuep = 0;
+      return 1;
+    }
+
+  if (CGEN_INT_INSN_P
+      && word_offset != 0)
+    abort ();
+
+  if (word_length > 32)
+    abort ();
+
+  /* For architectures with insns smaller than the insn-base-bitsize,
+     word_length may be too big.  */
+  if (cd->min_insn_bitsize < cd->base_insn_bitsize)
+    {
+      if (word_offset == 0
+	  && word_length > total_length)
+	word_length = total_length;
+    }
+
+  /* Does the value reside in INSN_VALUE?  */
+
+  if (word_offset == 0)
+    {
+      /* Written this way to avoid undefined behaviour.  */
+      CGEN_INSN_INT mask = (((1L << (length - 1)) - 1) << 1) | 1;
+
+      if (CGEN_INSN_LSB0_P)
+	value = insn_value >> ((start + 1) - length);
+      else
+	value = insn_value >> (word_length - (start + length));
+      value &= mask;
+      /* sign extend? */
+      if (CGEN_BOOL_ATTR (attrs, CGEN_IFLD_SIGNED)
+	  && (value & (1L << (length - 1))))
+	value |= ~mask;
+    }
+
+#if ! CGEN_INT_INSN_P
+
+  else
+    {
+      unsigned char *bufp = ex_info->insn_bytes + word_offset / 8;
+
+      if (word_length > 32)
+	abort ();
+
+      if (fill_cache (cd, ex_info, word_offset / 8, word_length / 8, pc) == 0)
+	return 0;
+
+      value = extract_1 (cd, ex_info, start, length, word_length, bufp, pc);
+    }
+
+#endif /* ! CGEN_INT_INSN_P */
+
+  *valuep = value;
+
+  return 1;
+}
+
+/* Default insn extractor.
+
+   INSN_VALUE is the first base_insn_bitsize bits, translated to host order.
+   The extracted fields are stored in FIELDS.
+   EX_INFO is used to handle reading variable length insns.
+   Return the length of the insn in bits, or 0 if no match,
+   or -1 if an error occurs fetching data (memory_error_func will have
+   been called).  */
+
+static int
+extract_insn_normal (cd, insn, ex_info, insn_value, fields, pc)
+     CGEN_CPU_DESC cd;
+     const CGEN_INSN *insn;
+     CGEN_EXTRACT_INFO *ex_info;
+     CGEN_INSN_INT insn_value;
+     CGEN_FIELDS *fields;
+     bfd_vma pc;
+{
+  const CGEN_SYNTAX *syntax = CGEN_INSN_SYNTAX (insn);
+  const unsigned char *syn;
+
+  CGEN_FIELDS_BITSIZE (fields) = CGEN_INSN_BITSIZE (insn);
+
+  CGEN_INIT_EXTRACT (cd);
+
+  for (syn = CGEN_SYNTAX_STRING (syntax); *syn; ++syn)
+    {
+      int length;
+
+      if (CGEN_SYNTAX_CHAR_P (*syn))
+	continue;
+
+      length = (* cd->extract_operand) (cd, CGEN_SYNTAX_FIELD (*syn),
+					ex_info, insn_value, fields, pc);
+      if (length <= 0)
+	return length;
+    }
+
+  /* We recognized and successfully extracted this insn.  */
+  return CGEN_INSN_BITSIZE (insn);
+}
+
+/* machine generated code added here */
+
+/* Main entry point for operand insertion.
+
+   This function is basically just a big switch statement.  Earlier versions
+   used tables to look up the function to use, but
+   - if the table contains both assembler and disassembler functions then
+     the disassembler contains much of the assembler and vice-versa,
+   - there's a lot of inlining possibilities as things grow,
+   - using a switch statement avoids the function call overhead.
+
+   This function could be moved into `parse_insn_normal', but keeping it
+   separate makes clear the interface between `parse_insn_normal' and each of
+   the handlers.  It's also needed by GAS to insert operands that couldn't be
+   resolved during parsing.
+*/
+
+const char *
+nios_cgen_insert_operand (cd, opindex, fields, buffer, pc)
+     CGEN_CPU_DESC cd;
+     int opindex;
+     CGEN_FIELDS * fields;
+     CGEN_INSN_BYTES_PTR buffer;
+     bfd_vma pc;
+{
+  const char * errmsg = NULL;
+  unsigned int total_length = CGEN_FIELDS_BITSIZE (fields);
+
+  switch (opindex)
+    {
+    case NIOS_OPERAND_CTLC :
+      errmsg = insert_normal (cd, fields->f_CTLc, 0, 0, 4, 3, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_RBI5 :
+      errmsg = insert_normal (cd, fields->f_Rbi5, 0, 0, 9, 5, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_BSRR_REL6 :
+      {
+        long value = fields->f_bsrr_i6_rel;
+        value = ((value) - (pc));
+        errmsg = insert_normal (cd, value, 0|(1<<CGEN_IFLD_PCREL_ADDR), 0, 10, 6, 16, total_length, buffer);
+      }
+      break;
+    case NIOS_OPERAND_I1 :
+      {
+        long value = fields->f_i1;
+        value = ((value) << (1));
+        errmsg = insert_normal (cd, value, 0, 0, 6, 2, 16, total_length, buffer);
+      }
+      break;
+    case NIOS_OPERAND_I10 :
+      errmsg = insert_normal (cd, fields->f_i10, 0, 0, 9, 10, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_I11 :
+      errmsg = insert_normal (cd, fields->f_i11, 0, 0, 10, 11, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_I2 :
+      errmsg = insert_normal (cd, fields->f_i2, 0, 0, 6, 2, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_I4W :
+      errmsg = insert_normal (cd, fields->f_i4w, 0, 0, 3, 4, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_I4WN :
+      errmsg = insert_normal (cd, fields->f_i4w, 0, 0, 3, 4, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_I5 :
+      errmsg = insert_normal (cd, fields->f_i5, 0, 0, 9, 5, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_I6V :
+      errmsg = insert_normal (cd, fields->f_i6v, 0, 0, 5, 6, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_I8 :
+      errmsg = insert_normal (cd, fields->f_i8, 0, 0, 12, 8, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_I8V :
+      errmsg = insert_normal (cd, fields->f_i8v, 0, 0, 7, 8, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_I9 :
+      errmsg = insert_normal (cd, fields->f_i9, 0, 0, 9, 9, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_M16_R0 :
+      break;
+    case NIOS_OPERAND_M16_RA :
+      errmsg = insert_normal (cd, fields->f_Ra, 0, 0, 4, 5, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_M16_RB :
+      errmsg = insert_normal (cd, fields->f_Rb, 0, 0, 9, 5, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_M16_RP :
+      errmsg = insert_normal (cd, fields->f_Rp, 0, 0, 11, 2, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_M16_RZ :
+      errmsg = insert_normal (cd, fields->f_Rz, 0, 0, 1, 2, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_M16_I6 :
+      {
+        long value = fields->f_i6_rel_h;
+        value = (((((value) | (pc))) == (0))) ? (0) : (((((unsigned int) (((value) - (pc))) >> (1))) - (2)));
+        errmsg = insert_normal (cd, value, 0|(1<<CGEN_IFLD_PCREL_ADDR), 0, 10, 6, 16, total_length, buffer);
+      }
+      break;
+    case NIOS_OPERAND_M16_I8V :
+      {
+        long value = fields->f_i8v_rel_h;
+        value = (((((value) | (pc))) == (0))) ? (0) : (((((unsigned int) (((value) - (pc))) >> (1))) - (1)));
+        errmsg = insert_normal (cd, value, 0|(1<<CGEN_IFLD_PCREL_ADDR), 0, 7, 8, 16, total_length, buffer);
+      }
+      break;
+    case NIOS_OPERAND_M16_SP :
+      break;
+    case NIOS_OPERAND_M32_R0 :
+      break;
+    case NIOS_OPERAND_M32_RA :
+      errmsg = insert_normal (cd, fields->f_Ra, 0, 0, 4, 5, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_M32_RB :
+      errmsg = insert_normal (cd, fields->f_Rb, 0, 0, 9, 5, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_M32_RP :
+      errmsg = insert_normal (cd, fields->f_Rp, 0, 0, 11, 2, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_M32_RZ :
+      errmsg = insert_normal (cd, fields->f_Rz, 0, 0, 1, 2, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_M32_I6 :
+      {
+        long value = fields->f_i6_rel_w;
+        value = (((((value) | (pc))) == (0))) ? (0) : (((((unsigned int) (((value) - (pc))) >> (2))) - (1)));
+        errmsg = insert_normal (cd, value, 0|(1<<CGEN_IFLD_PCREL_ADDR), 0, 10, 6, 16, total_length, buffer);
+      }
+      break;
+    case NIOS_OPERAND_M32_I8V :
+      {
+        long value = fields->f_i8v_rel_w;
+        value = (((((value) | (pc))) == (0))) ? (0) : (((((unsigned int) (((value) - (pc))) >> (1))) - (1)));
+        errmsg = insert_normal (cd, value, 0|(1<<CGEN_IFLD_PCREL_ADDR), 0, 7, 8, 16, total_length, buffer);
+      }
+      break;
+    case NIOS_OPERAND_M32_SP :
+      break;
+    case NIOS_OPERAND_O1 :
+      errmsg = insert_normal (cd, fields->f_o1, 0, 0, 5, 1, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_O2 :
+      errmsg = insert_normal (cd, fields->f_o2, 0, 0, 7, 2, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_REL11 :
+      {
+        long value = fields->f_i11_rel;
+        value = ((((int) (((value) - (pc))) >> (1))) - (1));
+        errmsg = insert_normal (cd, value, 0|(1<<CGEN_IFLD_SIGNED)|(1<<CGEN_IFLD_PCREL_ADDR), 0, 10, 11, 16, total_length, buffer);
+      }
+      break;
+    case NIOS_OPERAND_SAVE_I8V :
+      errmsg = insert_normal (cd, fields->f_i8v, 0, 0, 7, 8, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_SI11 :
+      errmsg = insert_normal (cd, fields->f_i11, 0, 0, 10, 11, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_SI5 :
+      errmsg = insert_normal (cd, fields->f_i5, 0, 0, 9, 5, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_X1 :
+      errmsg = insert_normal (cd, fields->f_x1, 0, 0, 4, 1, 16, total_length, buffer);
+      break;
+    case NIOS_OPERAND_XRA :
+      errmsg = insert_normal (cd, fields->f_Ra, 0, 0, 4, 5, 16, total_length, buffer);
+      break;
+
+    default :
+      /* xgettext:c-format */
+      fprintf (stderr, _("Unrecognized field %d while building insn.\n"),
+	       opindex);
+      abort ();
+  }
+
+  return errmsg;
+}
+
+/* Main entry point for operand extraction.
+   The result is <= 0 for error, >0 for success.
+   ??? Actual values aren't well defined right now.
+
+   This function is basically just a big switch statement.  Earlier versions
+   used tables to look up the function to use, but
+   - if the table contains both assembler and disassembler functions then
+     the disassembler contains much of the assembler and vice-versa,
+   - there's a lot of inlining possibilities as things grow,
+   - using a switch statement avoids the function call overhead.
+
+   This function could be moved into `print_insn_normal', but keeping it
+   separate makes clear the interface between `print_insn_normal' and each of
+   the handlers.
+*/
+
+int
+nios_cgen_extract_operand (cd, opindex, ex_info, insn_value, fields, pc)
+     CGEN_CPU_DESC cd;
+     int opindex;
+     CGEN_EXTRACT_INFO *ex_info;
+     CGEN_INSN_INT insn_value;
+     CGEN_FIELDS * fields;
+     bfd_vma pc;
+{
+  /* Assume success (for those operands that are nops).  */
+  int length = 1;
+  unsigned int total_length = CGEN_FIELDS_BITSIZE (fields);
+
+  switch (opindex)
+    {
+    case NIOS_OPERAND_CTLC :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 4, 3, 16, total_length, pc, & fields->f_CTLc);
+      break;
+    case NIOS_OPERAND_RBI5 :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 9, 5, 16, total_length, pc, & fields->f_Rbi5);
+      break;
+    case NIOS_OPERAND_BSRR_REL6 :
+      {
+        long value;
+        length = extract_normal (cd, ex_info, insn_value, 0|(1<<CGEN_IFLD_PCREL_ADDR), 0, 10, 6, 16, total_length, pc, & value);
+        value = ((pc) + (value));
+        fields->f_bsrr_i6_rel = value;
+      }
+      break;
+    case NIOS_OPERAND_I1 :
+      {
+        long value;
+        length = extract_normal (cd, ex_info, insn_value, 0, 0, 6, 2, 16, total_length, pc, & value);
+        value = ((unsigned int) (value) >> (1));
+        fields->f_i1 = value;
+      }
+      break;
+    case NIOS_OPERAND_I10 :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 9, 10, 16, total_length, pc, & fields->f_i10);
+      break;
+    case NIOS_OPERAND_I11 :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 10, 11, 16, total_length, pc, & fields->f_i11);
+      break;
+    case NIOS_OPERAND_I2 :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 6, 2, 16, total_length, pc, & fields->f_i2);
+      break;
+    case NIOS_OPERAND_I4W :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 3, 4, 16, total_length, pc, & fields->f_i4w);
+      break;
+    case NIOS_OPERAND_I4WN :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 3, 4, 16, total_length, pc, & fields->f_i4w);
+      break;
+    case NIOS_OPERAND_I5 :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 9, 5, 16, total_length, pc, & fields->f_i5);
+      break;
+    case NIOS_OPERAND_I6V :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 5, 6, 16, total_length, pc, & fields->f_i6v);
+      break;
+    case NIOS_OPERAND_I8 :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 12, 8, 16, total_length, pc, & fields->f_i8);
+      break;
+    case NIOS_OPERAND_I8V :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 7, 8, 16, total_length, pc, & fields->f_i8v);
+      break;
+    case NIOS_OPERAND_I9 :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 9, 9, 16, total_length, pc, & fields->f_i9);
+      break;
+    case NIOS_OPERAND_M16_R0 :
+      break;
+    case NIOS_OPERAND_M16_RA :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 4, 5, 16, total_length, pc, & fields->f_Ra);
+      break;
+    case NIOS_OPERAND_M16_RB :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 9, 5, 16, total_length, pc, & fields->f_Rb);
+      break;
+    case NIOS_OPERAND_M16_RP :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 11, 2, 16, total_length, pc, & fields->f_Rp);
+      break;
+    case NIOS_OPERAND_M16_RZ :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 1, 2, 16, total_length, pc, & fields->f_Rz);
+      break;
+    case NIOS_OPERAND_M16_I6 :
+      {
+        long value;
+        length = extract_normal (cd, ex_info, insn_value, 0|(1<<CGEN_IFLD_PCREL_ADDR), 0, 10, 6, 16, total_length, pc, & value);
+        value = ((((value) << (1))) + (((((pc) & (131070))) + (4))));
+        fields->f_i6_rel_h = value;
+      }
+      break;
+    case NIOS_OPERAND_M16_I8V :
+      {
+        long value;
+        length = extract_normal (cd, ex_info, insn_value, 0|(1<<CGEN_IFLD_PCREL_ADDR), 0, 7, 8, 16, total_length, pc, & value);
+        value = ((((value) << (1))) + (((((pc) & (131070))) + (2))));
+        fields->f_i8v_rel_h = value;
+      }
+      break;
+    case NIOS_OPERAND_M16_SP :
+      break;
+    case NIOS_OPERAND_M32_R0 :
+      break;
+    case NIOS_OPERAND_M32_RA :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 4, 5, 16, total_length, pc, & fields->f_Ra);
+      break;
+    case NIOS_OPERAND_M32_RB :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 9, 5, 16, total_length, pc, & fields->f_Rb);
+      break;
+    case NIOS_OPERAND_M32_RP :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 11, 2, 16, total_length, pc, & fields->f_Rp);
+      break;
+    case NIOS_OPERAND_M32_RZ :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 1, 2, 16, total_length, pc, & fields->f_Rz);
+      break;
+    case NIOS_OPERAND_M32_I6 :
+      {
+        long value;
+        length = extract_normal (cd, ex_info, insn_value, 0|(1<<CGEN_IFLD_PCREL_ADDR), 0, 10, 6, 16, total_length, pc, & value);
+        value = ((((value) << (2))) + (((((pc) & (0xfffffffc))) + (4))));
+        fields->f_i6_rel_w = value;
+      }
+      break;
+    case NIOS_OPERAND_M32_I8V :
+      {
+        long value;
+        length = extract_normal (cd, ex_info, insn_value, 0|(1<<CGEN_IFLD_PCREL_ADDR), 0, 7, 8, 16, total_length, pc, & value);
+        value = ((((((value) << (1))) + (((pc) + (2))))) & (0xfffffffc));
+        fields->f_i8v_rel_w = value;
+      }
+      break;
+    case NIOS_OPERAND_M32_SP :
+      break;
+    case NIOS_OPERAND_O1 :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 5, 1, 16, total_length, pc, & fields->f_o1);
+      break;
+    case NIOS_OPERAND_O2 :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 7, 2, 16, total_length, pc, & fields->f_o2);
+      break;
+    case NIOS_OPERAND_REL11 :
+      {
+        long value;
+        length = extract_normal (cd, ex_info, insn_value, 0|(1<<CGEN_IFLD_SIGNED)|(1<<CGEN_IFLD_PCREL_ADDR), 0, 10, 11, 16, total_length, pc, & value);
+        value = ((((((value) << (1))) + (pc))) + (2));
+        fields->f_i11_rel = value;
+      }
+      break;
+    case NIOS_OPERAND_SAVE_I8V :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 7, 8, 16, total_length, pc, & fields->f_i8v);
+      break;
+    case NIOS_OPERAND_SI11 :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 10, 11, 16, total_length, pc, & fields->f_i11);
+      break;
+    case NIOS_OPERAND_SI5 :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 9, 5, 16, total_length, pc, & fields->f_i5);
+      break;
+    case NIOS_OPERAND_X1 :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 4, 1, 16, total_length, pc, & fields->f_x1);
+      break;
+    case NIOS_OPERAND_XRA :
+      length = extract_normal (cd, ex_info, insn_value, 0, 0, 4, 5, 16, total_length, pc, & fields->f_Ra);
+      break;
+
+    default :
+      /* xgettext:c-format */
+      fprintf (stderr, _("Unrecognized field %d while decoding insn.\n"),
+	       opindex);
+      abort ();
+    }
+
+  return length;
+}
+
+cgen_insert_fn * const nios_cgen_insert_handlers[] = 
+{
+  insert_insn_normal,
+};
+
+cgen_extract_fn * const nios_cgen_extract_handlers[] = 
+{
+  extract_insn_normal,
+};
+
+/* Getting values from cgen_fields is handled by a collection of functions.
+   They are distinguished by the type of the VALUE argument they return.
+   TODO: floating point, inlining support, remove cases where result type
+   not appropriate.  */
+
+int
+nios_cgen_get_int_operand (cd, opindex, fields)
+     CGEN_CPU_DESC cd;
+     int opindex;
+     const CGEN_FIELDS * fields;
+{
+  int value;
+
+  switch (opindex)
+    {
+    case NIOS_OPERAND_CTLC :
+      value = fields->f_CTLc;
+      break;
+    case NIOS_OPERAND_RBI5 :
+      value = fields->f_Rbi5;
+      break;
+    case NIOS_OPERAND_BSRR_REL6 :
+      value = fields->f_bsrr_i6_rel;
+      break;
+    case NIOS_OPERAND_I1 :
+      value = fields->f_i1;
+      break;
+    case NIOS_OPERAND_I10 :
+      value = fields->f_i10;
+      break;
+    case NIOS_OPERAND_I11 :
+      value = fields->f_i11;
+      break;
+    case NIOS_OPERAND_I2 :
+      value = fields->f_i2;
+      break;
+    case NIOS_OPERAND_I4W :
+      value = fields->f_i4w;
+      break;
+    case NIOS_OPERAND_I4WN :
+      value = fields->f_i4w;
+      break;
+    case NIOS_OPERAND_I5 :
+      value = fields->f_i5;
+      break;
+    case NIOS_OPERAND_I6V :
+      value = fields->f_i6v;
+      break;
+    case NIOS_OPERAND_I8 :
+      value = fields->f_i8;
+      break;
+    case NIOS_OPERAND_I8V :
+      value = fields->f_i8v;
+      break;
+    case NIOS_OPERAND_I9 :
+      value = fields->f_i9;
+      break;
+    case NIOS_OPERAND_M16_R0 :
+      value = 0;
+      break;
+    case NIOS_OPERAND_M16_RA :
+      value = fields->f_Ra;
+      break;
+    case NIOS_OPERAND_M16_RB :
+      value = fields->f_Rb;
+      break;
+    case NIOS_OPERAND_M16_RP :
+      value = fields->f_Rp;
+      break;
+    case NIOS_OPERAND_M16_RZ :
+      value = fields->f_Rz;
+      break;
+    case NIOS_OPERAND_M16_I6 :
+      value = fields->f_i6_rel_h;
+      break;
+    case NIOS_OPERAND_M16_I8V :
+      value = fields->f_i8v_rel_h;
+      break;
+    case NIOS_OPERAND_M16_SP :
+      value = 0;
+      break;
+    case NIOS_OPERAND_M32_R0 :
+      value = 0;
+      break;
+    case NIOS_OPERAND_M32_RA :
+      value = fields->f_Ra;
+      break;
+    case NIOS_OPERAND_M32_RB :
+      value = fields->f_Rb;
+      break;
+    case NIOS_OPERAND_M32_RP :
+      value = fields->f_Rp;
+      break;
+    case NIOS_OPERAND_M32_RZ :
+      value = fields->f_Rz;
+      break;
+    case NIOS_OPERAND_M32_I6 :
+      value = fields->f_i6_rel_w;
+      break;
+    case NIOS_OPERAND_M32_I8V :
+      value = fields->f_i8v_rel_w;
+      break;
+    case NIOS_OPERAND_M32_SP :
+      value = 0;
+      break;
+    case NIOS_OPERAND_O1 :
+      value = fields->f_o1;
+      break;
+    case NIOS_OPERAND_O2 :
+      value = fields->f_o2;
+      break;
+    case NIOS_OPERAND_REL11 :
+      value = fields->f_i11_rel;
+      break;
+    case NIOS_OPERAND_SAVE_I8V :
+      value = fields->f_i8v;
+      break;
+    case NIOS_OPERAND_SI11 :
+      value = fields->f_i11;
+      break;
+    case NIOS_OPERAND_SI5 :
+      value = fields->f_i5;
+      break;
+    case NIOS_OPERAND_X1 :
+      value = fields->f_x1;
+      break;
+    case NIOS_OPERAND_XRA :
+      value = fields->f_Ra;
+      break;
+
+    default :
+      /* xgettext:c-format */
+      fprintf (stderr, _("Unrecognized field %d while getting int operand.\n"),
+		       opindex);
+      abort ();
+  }
+
+  return value;
+}
+
+bfd_vma
+nios_cgen_get_vma_operand (cd, opindex, fields)
+     CGEN_CPU_DESC cd;
+     int opindex;
+     const CGEN_FIELDS * fields;
+{
+  bfd_vma value;
+
+  switch (opindex)
+    {
+    case NIOS_OPERAND_CTLC :
+      value = fields->f_CTLc;
+      break;
+    case NIOS_OPERAND_RBI5 :
+      value = fields->f_Rbi5;
+      break;
+    case NIOS_OPERAND_BSRR_REL6 :
+      value = fields->f_bsrr_i6_rel;
+      break;
+    case NIOS_OPERAND_I1 :
+      value = fields->f_i1;
+      break;
+    case NIOS_OPERAND_I10 :
+      value = fields->f_i10;
+      break;
+    case NIOS_OPERAND_I11 :
+      value = fields->f_i11;
+      break;
+    case NIOS_OPERAND_I2 :
+      value = fields->f_i2;
+      break;
+    case NIOS_OPERAND_I4W :
+      value = fields->f_i4w;
+      break;
+    case NIOS_OPERAND_I4WN :
+      value = fields->f_i4w;
+      break;
+    case NIOS_OPERAND_I5 :
+      value = fields->f_i5;
+      break;
+    case NIOS_OPERAND_I6V :
+      value = fields->f_i6v;
+      break;
+    case NIOS_OPERAND_I8 :
+      value = fields->f_i8;
+      break;
+    case NIOS_OPERAND_I8V :
+      value = fields->f_i8v;
+      break;
+    case NIOS_OPERAND_I9 :
+      value = fields->f_i9;
+      break;
+    case NIOS_OPERAND_M16_R0 :
+      value = 0;
+      break;
+    case NIOS_OPERAND_M16_RA :
+      value = fields->f_Ra;
+      break;
+    case NIOS_OPERAND_M16_RB :
+      value = fields->f_Rb;
+      break;
+    case NIOS_OPERAND_M16_RP :
+      value = fields->f_Rp;
+      break;
+    case NIOS_OPERAND_M16_RZ :
+      value = fields->f_Rz;
+      break;
+    case NIOS_OPERAND_M16_I6 :
+      value = fields->f_i6_rel_h;
+      break;
+    case NIOS_OPERAND_M16_I8V :
+      value = fields->f_i8v_rel_h;
+      break;
+    case NIOS_OPERAND_M16_SP :
+      value = 0;
+      break;
+    case NIOS_OPERAND_M32_R0 :
+      value = 0;
+      break;
+    case NIOS_OPERAND_M32_RA :
+      value = fields->f_Ra;
+      break;
+    case NIOS_OPERAND_M32_RB :
+      value = fields->f_Rb;
+      break;
+    case NIOS_OPERAND_M32_RP :
+      value = fields->f_Rp;
+      break;
+    case NIOS_OPERAND_M32_RZ :
+      value = fields->f_Rz;
+      break;
+    case NIOS_OPERAND_M32_I6 :
+      value = fields->f_i6_rel_w;
+      break;
+    case NIOS_OPERAND_M32_I8V :
+      value = fields->f_i8v_rel_w;
+      break;
+    case NIOS_OPERAND_M32_SP :
+      value = 0;
+      break;
+    case NIOS_OPERAND_O1 :
+      value = fields->f_o1;
+      break;
+    case NIOS_OPERAND_O2 :
+      value = fields->f_o2;
+      break;
+    case NIOS_OPERAND_REL11 :
+      value = fields->f_i11_rel;
+      break;
+    case NIOS_OPERAND_SAVE_I8V :
+      value = fields->f_i8v;
+      break;
+    case NIOS_OPERAND_SI11 :
+      value = fields->f_i11;
+      break;
+    case NIOS_OPERAND_SI5 :
+      value = fields->f_i5;
+      break;
+    case NIOS_OPERAND_X1 :
+      value = fields->f_x1;
+      break;
+    case NIOS_OPERAND_XRA :
+      value = fields->f_Ra;
+      break;
+
+    default :
+      /* xgettext:c-format */
+      fprintf (stderr, _("Unrecognized field %d while getting vma operand.\n"),
+		       opindex);
+      abort ();
+  }
+
+  return value;
+}
+
+/* Stuffing values in cgen_fields is handled by a collection of functions.
+   They are distinguished by the type of the VALUE argument they accept.
+   TODO: floating point, inlining support, remove cases where argument type
+   not appropriate.  */
+
+void
+nios_cgen_set_int_operand (cd, opindex, fields, value)
+     CGEN_CPU_DESC cd;
+     int opindex;
+     CGEN_FIELDS * fields;
+     int value;
+{
+  switch (opindex)
+    {
+    case NIOS_OPERAND_CTLC :
+      fields->f_CTLc = value;
+      break;
+    case NIOS_OPERAND_RBI5 :
+      fields->f_Rbi5 = value;
+      break;
+    case NIOS_OPERAND_BSRR_REL6 :
+      fields->f_bsrr_i6_rel = value;
+      break;
+    case NIOS_OPERAND_I1 :
+      fields->f_i1 = value;
+      break;
+    case NIOS_OPERAND_I10 :
+      fields->f_i10 = value;
+      break;
+    case NIOS_OPERAND_I11 :
+      fields->f_i11 = value;
+      break;
+    case NIOS_OPERAND_I2 :
+      fields->f_i2 = value;
+      break;
+    case NIOS_OPERAND_I4W :
+      fields->f_i4w = value;
+      break;
+    case NIOS_OPERAND_I4WN :
+      fields->f_i4w = value;
+      break;
+    case NIOS_OPERAND_I5 :
+      fields->f_i5 = value;
+      break;
+    case NIOS_OPERAND_I6V :
+      fields->f_i6v = value;
+      break;
+    case NIOS_OPERAND_I8 :
+      fields->f_i8 = value;
+      break;
+    case NIOS_OPERAND_I8V :
+      fields->f_i8v = value;
+      break;
+    case NIOS_OPERAND_I9 :
+      fields->f_i9 = value;
+      break;
+    case NIOS_OPERAND_M16_R0 :
+      break;
+    case NIOS_OPERAND_M16_RA :
+      fields->f_Ra = value;
+      break;
+    case NIOS_OPERAND_M16_RB :
+      fields->f_Rb = value;
+      break;
+    case NIOS_OPERAND_M16_RP :
+      fields->f_Rp = value;
+      break;
+    case NIOS_OPERAND_M16_RZ :
+      fields->f_Rz = value;
+      break;
+    case NIOS_OPERAND_M16_I6 :
+      fields->f_i6_rel_h = value;
+      break;
+    case NIOS_OPERAND_M16_I8V :
+      fields->f_i8v_rel_h = value;
+      break;
+    case NIOS_OPERAND_M16_SP :
+      break;
+    case NIOS_OPERAND_M32_R0 :
+      break;
+    case NIOS_OPERAND_M32_RA :
+      fields->f_Ra = value;
+      break;
+    case NIOS_OPERAND_M32_RB :
+      fields->f_Rb = value;
+      break;
+    case NIOS_OPERAND_M32_RP :
+      fields->f_Rp = value;
+      break;
+    case NIOS_OPERAND_M32_RZ :
+      fields->f_Rz = value;
+      break;
+    case NIOS_OPERAND_M32_I6 :
+      fields->f_i6_rel_w = value;
+      break;
+    case NIOS_OPERAND_M32_I8V :
+      fields->f_i8v_rel_w = value;
+      break;
+    case NIOS_OPERAND_M32_SP :
+      break;
+    case NIOS_OPERAND_O1 :
+      fields->f_o1 = value;
+      break;
+    case NIOS_OPERAND_O2 :
+      fields->f_o2 = value;
+      break;
+    case NIOS_OPERAND_REL11 :
+      fields->f_i11_rel = value;
+      break;
+    case NIOS_OPERAND_SAVE_I8V :
+      fields->f_i8v = value;
+      break;
+    case NIOS_OPERAND_SI11 :
+      fields->f_i11 = value;
+      break;
+    case NIOS_OPERAND_SI5 :
+      fields->f_i5 = value;
+      break;
+    case NIOS_OPERAND_X1 :
+      fields->f_x1 = value;
+      break;
+    case NIOS_OPERAND_XRA :
+      fields->f_Ra = value;
+      break;
+
+    default :
+      /* xgettext:c-format */
+      fprintf (stderr, _("Unrecognized field %d while setting int operand.\n"),
+		       opindex);
+      abort ();
+  }
+}
+
+void
+nios_cgen_set_vma_operand (cd, opindex, fields, value)
+     CGEN_CPU_DESC cd;
+     int opindex;
+     CGEN_FIELDS * fields;
+     bfd_vma value;
+{
+  switch (opindex)
+    {
+    case NIOS_OPERAND_CTLC :
+      fields->f_CTLc = value;
+      break;
+    case NIOS_OPERAND_RBI5 :
+      fields->f_Rbi5 = value;
+      break;
+    case NIOS_OPERAND_BSRR_REL6 :
+      fields->f_bsrr_i6_rel = value;
+      break;
+    case NIOS_OPERAND_I1 :
+      fields->f_i1 = value;
+      break;
+    case NIOS_OPERAND_I10 :
+      fields->f_i10 = value;
+      break;
+    case NIOS_OPERAND_I11 :
+      fields->f_i11 = value;
+      break;
+    case NIOS_OPERAND_I2 :
+      fields->f_i2 = value;
+      break;
+    case NIOS_OPERAND_I4W :
+      fields->f_i4w = value;
+      break;
+    case NIOS_OPERAND_I4WN :
+      fields->f_i4w = value;
+      break;
+    case NIOS_OPERAND_I5 :
+      fields->f_i5 = value;
+      break;
+    case NIOS_OPERAND_I6V :
+      fields->f_i6v = value;
+      break;
+    case NIOS_OPERAND_I8 :
+      fields->f_i8 = value;
+      break;
+    case NIOS_OPERAND_I8V :
+      fields->f_i8v = value;
+      break;
+    case NIOS_OPERAND_I9 :
+      fields->f_i9 = value;
+      break;
+    case NIOS_OPERAND_M16_R0 :
+      break;
+    case NIOS_OPERAND_M16_RA :
+      fields->f_Ra = value;
+      break;
+    case NIOS_OPERAND_M16_RB :
+      fields->f_Rb = value;
+      break;
+    case NIOS_OPERAND_M16_RP :
+      fields->f_Rp = value;
+      break;
+    case NIOS_OPERAND_M16_RZ :
+      fields->f_Rz = value;
+      break;
+    case NIOS_OPERAND_M16_I6 :
+      fields->f_i6_rel_h = value;
+      break;
+    case NIOS_OPERAND_M16_I8V :
+      fields->f_i8v_rel_h = value;
+      break;
+    case NIOS_OPERAND_M16_SP :
+      break;
+    case NIOS_OPERAND_M32_R0 :
+      break;
+    case NIOS_OPERAND_M32_RA :
+      fields->f_Ra = value;
+      break;
+    case NIOS_OPERAND_M32_RB :
+      fields->f_Rb = value;
+      break;
+    case NIOS_OPERAND_M32_RP :
+      fields->f_Rp = value;
+      break;
+    case NIOS_OPERAND_M32_RZ :
+      fields->f_Rz = value;
+      break;
+    case NIOS_OPERAND_M32_I6 :
+      fields->f_i6_rel_w = value;
+      break;
+    case NIOS_OPERAND_M32_I8V :
+      fields->f_i8v_rel_w = value;
+      break;
+    case NIOS_OPERAND_M32_SP :
+      break;
+    case NIOS_OPERAND_O1 :
+      fields->f_o1 = value;
+      break;
+    case NIOS_OPERAND_O2 :
+      fields->f_o2 = value;
+      break;
+    case NIOS_OPERAND_REL11 :
+      fields->f_i11_rel = value;
+      break;
+    case NIOS_OPERAND_SAVE_I8V :
+      fields->f_i8v = value;
+      break;
+    case NIOS_OPERAND_SI11 :
+      fields->f_i11 = value;
+      break;
+    case NIOS_OPERAND_SI5 :
+      fields->f_i5 = value;
+      break;
+    case NIOS_OPERAND_X1 :
+      fields->f_x1 = value;
+      break;
+    case NIOS_OPERAND_XRA :
+      fields->f_Ra = value;
+      break;
+
+    default :
+      /* xgettext:c-format */
+      fprintf (stderr, _("Unrecognized field %d while setting vma operand.\n"),
+		       opindex);
+      abort ();
+  }
+}
+
+/* Function to call before using the instruction builder tables.  */
+
+void
+nios_cgen_init_ibld_table (cd)
+     CGEN_CPU_DESC cd;
+{
+  cd->insert_handlers = & nios_cgen_insert_handlers[0];
+  cd->extract_handlers = & nios_cgen_extract_handlers[0];
+
+  cd->insert_operand = nios_cgen_insert_operand;
+  cd->extract_operand = nios_cgen_extract_operand;
+
+  cd->get_int_operand = nios_cgen_get_int_operand;
+  cd->set_int_operand = nios_cgen_set_int_operand;
+  cd->get_vma_operand = nios_cgen_get_vma_operand;
+  cd->set_vma_operand = nios_cgen_set_vma_operand;
+}

--- a/libr/asm/arch/nios/gnu/nios-ibld.c
+++ b/libr/asm/arch/nios/gnu/nios-ibld.c
@@ -1,25 +1,25 @@
 /* Instruction building/extraction support for nios. -*- C -*-
 
-THIS FILE IS MACHINE GENERATED WITH CGEN: Cpu tools GENerator.
-- the resultant file is machine generated, cgen-ibld.in isn't
+   THIS FILE IS MACHINE GENERATED WITH CGEN: Cpu tools GENerator.
+   - the resultant file is machine generated, cgen-ibld.in isn't
 
-Copyright (C) 1996, 1997, 1998, 1999, 2000 Free Software Foundation, Inc.
+   Copyright (C) 1996-2018 Free Software Foundation, Inc.
 
-This file is part of the GNU Binutils and GDB, the GNU debugger.
+   This file is part of libopcodes.
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2, or (at your option)
-any later version.
+   This library is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3, or (at your option)
+   any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+   It is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+   License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software Foundation, Inc.,
-59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.  */
 
 /* ??? Eventually more and more of this stuff can go to cpu-independent files.
    Keep that in mind.  */
@@ -27,6 +27,7 @@ along with this program; if not, write to the Free Software Foundation, Inc.,
 #include "sysdep.h"
 #include <ctype.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "ansidecl.h"
 #include "dis-asm.h"
 //#include "bfd.h"
@@ -35,29 +36,41 @@ along with this program; if not, write to the Free Software Foundation, Inc.,
 #include "nios-desc.h"
 #include "nios-opc.h"
 #include "opintl.h"
+#include "safe-ctype.h"
 
-#undef min
+#undef  min
 #define min(a,b) ((a) < (b) ? (a) : (b))
-#undef max
+#undef  max
 #define max(a,b) ((a) > (b) ? (a) : (b))
 
 /* Used by the ifield rtx function.  */
 #define FLD(f) (fields->f)
 
 static const char * insert_normal
-     PARAMS ((CGEN_CPU_DESC, long, unsigned int, unsigned int, unsigned int,
-	      unsigned int, unsigned int, unsigned int, CGEN_INSN_BYTES_PTR));
+  (CGEN_CPU_DESC, long, unsigned int, unsigned int, unsigned int,
+   unsigned int, unsigned int, unsigned int, CGEN_INSN_BYTES_PTR);
 static const char * insert_insn_normal
-     PARAMS ((CGEN_CPU_DESC, const CGEN_INSN *,
-	      CGEN_FIELDS *, CGEN_INSN_BYTES_PTR, bfd_vma));
-
+  (CGEN_CPU_DESC, const CGEN_INSN *,
+   CGEN_FIELDS *, CGEN_INSN_BYTES_PTR, bfd_vma);
 static int extract_normal
-     PARAMS ((CGEN_CPU_DESC, CGEN_EXTRACT_INFO *, CGEN_INSN_INT,
-	      unsigned int, unsigned int, unsigned int, unsigned int,
-	      unsigned int, unsigned int, bfd_vma, long *));
+  (CGEN_CPU_DESC, CGEN_EXTRACT_INFO *, CGEN_INSN_INT,
+   unsigned int, unsigned int, unsigned int, unsigned int,
+   unsigned int, unsigned int, bfd_vma, long *);
 static int extract_insn_normal
-     PARAMS ((CGEN_CPU_DESC, const CGEN_INSN *, CGEN_EXTRACT_INFO *,
-	      CGEN_INSN_INT, CGEN_FIELDS *, bfd_vma));
+  (CGEN_CPU_DESC, const CGEN_INSN *, CGEN_EXTRACT_INFO *,
+   CGEN_INSN_INT, CGEN_FIELDS *, bfd_vma);
+#if CGEN_INT_INSN_P
+static void put_insn_int_value
+  (CGEN_CPU_DESC, CGEN_INSN_BYTES_PTR, int, int, CGEN_INSN_INT);
+#endif
+#if ! CGEN_INT_INSN_P
+static CGEN_INLINE void insert_1
+  (CGEN_CPU_DESC, unsigned long, int, int, int, unsigned char *);
+static CGEN_INLINE int fill_cache
+  (CGEN_CPU_DESC, CGEN_EXTRACT_INFO *,  int, int, bfd_vma);
+static CGEN_INLINE long extract_1
+  (CGEN_CPU_DESC, CGEN_EXTRACT_INFO *, int, int, int, unsigned char *, bfd_vma);
+#endif
 
 /* Operand insertion.  */
 
@@ -66,44 +79,17 @@ static int extract_insn_normal
 /* Subroutine of insert_normal.  */
 
 static CGEN_INLINE void
-insert_1 (cd, value, start, length, word_length, bufp)
-     CGEN_CPU_DESC cd;
-     unsigned long value;
-     int start,length,word_length;
-     unsigned char *bufp;
+insert_1 (CGEN_CPU_DESC cd,
+	  unsigned long value,
+	  int start,
+	  int length,
+	  int word_length,
+	  unsigned char *bufp)
 {
   unsigned long x,mask;
   int shift;
-  int big_p = CGEN_CPU_INSN_ENDIAN (cd) == CGEN_ENDIAN_BIG;
 
-  switch (word_length)
-    {
-    case 8:
-      x = *bufp;
-      break;
-    case 16:
-      if (big_p)
-	x = bfd_getb16 (bufp);
-      else
-	x = bfd_getl16 (bufp);
-      break;
-    case 24:
-      /* ??? This may need reworking as these cases don't necessarily
-	 want the first byte and the last two bytes handled like this.  */
-      if (big_p)
-	x = (bufp[0] << 16) | bfd_getb16 (bufp + 1);
-      else
-	x = bfd_getl16 (bufp) | (bufp[2] << 16);
-      break;
-    case 32:
-      if (big_p)
-	x = bfd_getb32 (bufp);
-      else
-	x = bfd_getl32 (bufp);
-      break;
-    default :
-      abort ();
-    }
+  x = cgen_get_insn_value (cd, bufp, word_length);
 
   /* Written this way to avoid undefined behaviour.  */
   mask = (((1L << (length - 1)) - 1) << 1) | 1;
@@ -113,40 +99,7 @@ insert_1 (cd, value, start, length, word_length, bufp)
     shift = (word_length - (start + length));
   x = (x & ~(mask << shift)) | ((value & mask) << shift);
 
-  switch (word_length)
-    {
-    case 8:
-      *bufp = x;
-      break;
-    case 16:
-      if (big_p)
-	bfd_putb16 (x, bufp);
-      else
-	bfd_putl16 (x, bufp);
-      break;
-    case 24:
-      /* ??? This may need reworking as these cases don't necessarily
-	 want the first byte and the last two bytes handled like this.  */
-      if (big_p)
-	{
-	  bufp[0] = x >> 16;
-	  bfd_putb16 (x, bufp + 1);
-	}
-      else
-	{
-	  bfd_putl16 (x, bufp);
-	  bufp[2] = x >> 16;
-	}
-      break;
-    case 32:
-      if (big_p)
-	bfd_putb32 (x, bufp);
-      else
-	bfd_putl32 (x, bufp);
-      break;
-    default :
-      abort ();
-    }
+  cgen_put_insn_value (cd, bufp, word_length, (bfd_vma) x);
 }
 
 #endif /* ! CGEN_INT_INSN_P */
@@ -168,13 +121,15 @@ insert_1 (cd, value, start, length, word_length, bufp)
    necessary.  */
 
 static const char *
-insert_normal (cd, value, attrs, word_offset, start, length, word_length,
-	       total_length, buffer)
-     CGEN_CPU_DESC cd;
-     long value;
-     unsigned int attrs;
-     unsigned int word_offset, start, length, word_length, total_length;
-     CGEN_INSN_BYTES_PTR buffer;
+insert_normal (CGEN_CPU_DESC cd,
+	       long value,
+	       unsigned int attrs,
+	       unsigned int word_offset,
+	       unsigned int start,
+	       unsigned int length,
+	       unsigned int word_length,
+	       unsigned int total_length,
+	       CGEN_INSN_BYTES_PTR buffer)
 {
   static char errbuf[100];
   /* Written this way to avoid undefined behaviour.  */
@@ -184,11 +139,7 @@ insert_normal (cd, value, attrs, word_offset, start, length, word_length,
   if (length == 0)
     return NULL;
 
-  if (CGEN_INT_INSN_P
-      && word_offset != 0)
-    abort ();
-
-  if (word_length > 32)
+  if (word_length > 8 * sizeof (CGEN_INSN_INT))
     abort ();
 
   /* For architectures with insns smaller than the base-insn-bitsize,
@@ -201,16 +152,39 @@ insert_normal (cd, value, attrs, word_offset, start, length, word_length,
     }
 
   /* Ensure VALUE will fit.  */
-  if (! CGEN_BOOL_ATTR (attrs, CGEN_IFLD_SIGNED))
+  if (CGEN_BOOL_ATTR (attrs, CGEN_IFLD_SIGN_OPT))
     {
+      long minval = - (1L << (length - 1));
       unsigned long maxval = mask;
-      
-      if ((unsigned long) value > maxval)
+
+      if ((value > 0 && (unsigned long) value > maxval)
+	  || value < minval)
 	{
 	  /* xgettext:c-format */
 	  sprintf (errbuf,
-		   _("operand out of range (%lu not between 0 and %lu)"),
-		   value, maxval);
+		   _("operand out of range (%ld not between %ld and %lu)"),
+		   value, minval, maxval);
+	  return errbuf;
+	}
+    }
+  else if (! CGEN_BOOL_ATTR (attrs, CGEN_IFLD_SIGNED))
+    {
+      unsigned long maxval = mask;
+      unsigned long val = (unsigned long) value;
+
+      /* For hosts with a word size > 32 check to see if value has been sign
+	 extended beyond 32 bits.  If so then ignore these higher sign bits
+	 as the user is attempting to store a 32-bit signed value into an
+	 unsigned 32-bit field which is allowed.  */
+      if (sizeof (unsigned long) > 4 && ((value >> 32) == -1))
+	val &= 0xFFFFFFFF;
+
+      if (val > maxval)
+	{
+	  /* xgettext:c-format */
+	  sprintf (errbuf,
+		   _("operand out of range (0x%lx not between 0 and 0x%lx)"),
+		   val, maxval);
 	  return errbuf;
 	}
     }
@@ -220,7 +194,7 @@ insert_normal (cd, value, attrs, word_offset, start, length, word_length,
 	{
 	  long minval = - (1L << (length - 1));
 	  long maxval =   (1L << (length - 1)) - 1;
-	  
+
 	  if (value < minval || value > maxval)
 	    {
 	      sprintf
@@ -235,12 +209,19 @@ insert_normal (cd, value, attrs, word_offset, start, length, word_length,
 #if CGEN_INT_INSN_P
 
   {
-    int shift;
+    int shift_within_word, shift_to_word, shift;
 
+    /* How to shift the value to BIT0 of the word.  */
+    shift_to_word = total_length - (word_offset + word_length);
+
+    /* How to shift the value to the field within the word.  */
     if (CGEN_INSN_LSB0_P)
-      shift = (start + 1) - length;
+      shift_within_word = start + 1 - length;
     else
-      shift = word_length - (start + length);
+      shift_within_word = word_length - start - length;
+
+    /* The total SHIFT, then mask in the value.  */
+    shift = shift_to_word + shift_within_word;
     *buffer = (*buffer & ~(mask << shift)) | ((value & mask) << shift);
   }
 
@@ -258,23 +239,22 @@ insert_normal (cd, value, attrs, word_offset, start, length, word_length,
 }
 
 /* Default insn builder (insert handler).
-   The instruction is recorded in CGEN_INT_INSN_P byte order
-   (meaning that if CGEN_INT_INSN_P BUFFER is an int * and thus the value is
-   recorded in host byte order, otherwise BUFFER is an array of bytes and the
-   value is recorded in target byte order).
+   The instruction is recorded in CGEN_INT_INSN_P byte order (meaning
+   that if CGEN_INSN_BYTES_PTR is an int * and thus, the value is
+   recorded in host byte order, otherwise BUFFER is an array of bytes
+   and the value is recorded in target byte order).
    The result is an error message or NULL if success.  */
 
 static const char *
-insert_insn_normal (cd, insn, fields, buffer, pc)
-     CGEN_CPU_DESC cd;
-     const CGEN_INSN * insn;
-     CGEN_FIELDS * fields;
-     CGEN_INSN_BYTES_PTR buffer;
-     bfd_vma pc;
+insert_insn_normal (CGEN_CPU_DESC cd,
+		    const CGEN_INSN * insn,
+		    CGEN_FIELDS * fields,
+		    CGEN_INSN_BYTES_PTR buffer,
+		    bfd_vma pc)
 {
   const CGEN_SYNTAX *syntax = CGEN_INSN_SYNTAX (insn);
   unsigned long value;
-  const unsigned char * syn;
+  const CGEN_SYNTAX_CHAR_TYPE * syn;
 
   CGEN_INIT_INSERT (cd);
   value = CGEN_INSN_BASE_VALUE (insn);
@@ -284,12 +264,13 @@ insert_insn_normal (cd, insn, fields, buffer, pc)
 
 #if CGEN_INT_INSN_P
 
-  *buffer = value;
+  put_insn_int_value (cd, buffer, cd->base_insn_bitsize,
+		      CGEN_FIELDS_BITSIZE (fields), value);
 
 #else
 
-  cgen_put_insn_value (cd, buffer, min (cd->base_insn_bitsize,
-					CGEN_FIELDS_BITSIZE (fields)),
+  cgen_put_insn_value (cd, buffer, min ((unsigned) cd->base_insn_bitsize,
+					(unsigned) CGEN_FIELDS_BITSIZE (fields)),
 		       value);
 
 #endif /* ! CGEN_INT_INSN_P */
@@ -299,7 +280,7 @@ insert_insn_normal (cd, insn, fields, buffer, pc)
      e.g. storing a branch displacement that got resolved later.
      Needs more thought first.  */
 
-  for (syn = CGEN_SYNTAX_STRING (syntax); * syn != '\0'; ++ syn)
+  for (syn = CGEN_SYNTAX_STRING (syntax); * syn; ++ syn)
     {
       const char *errmsg;
 
@@ -314,6 +295,32 @@ insert_insn_normal (cd, insn, fields, buffer, pc)
 
   return NULL;
 }
+
+#if CGEN_INT_INSN_P
+/* Cover function to store an insn value into an integral insn.  Must go here
+   because it needs <prefix>-desc.h for CGEN_INT_INSN_P.  */
+
+static void
+put_insn_int_value (CGEN_CPU_DESC cd ATTRIBUTE_UNUSED,
+		    CGEN_INSN_BYTES_PTR buf,
+		    int length,
+		    int insn_length,
+		    CGEN_INSN_INT value)
+{
+  /* For architectures with insns smaller than the base-insn-bitsize,
+     length may be too big.  */
+  if (length > insn_length)
+    *buf = value;
+  else
+    {
+      int shift = insn_length - length;
+      /* Written this way to avoid undefined behaviour.  */
+      CGEN_INSN_INT mask = (((1L << (length - 1)) - 1) << 1) | 1;
+
+      *buf = (*buf & ~(mask << shift)) | ((value & mask) << shift);
+    }
+}
+#endif
 
 /* Operand extraction.  */
 
@@ -326,15 +333,15 @@ insert_insn_normal (cd, insn, fields, buffer, pc)
    Returns 1 for success, 0 for failure.  */
 
 static CGEN_INLINE int
-fill_cache (cd, ex_info, offset, bytes, pc)
-     CGEN_CPU_DESC cd;
-     CGEN_EXTRACT_INFO *ex_info;
-     int offset, bytes;
-     bfd_vma pc;
+fill_cache (CGEN_CPU_DESC cd ATTRIBUTE_UNUSED,
+	    CGEN_EXTRACT_INFO *ex_info,
+	    int offset,
+	    int bytes,
+	    bfd_vma pc)
 {
   /* It's doubtful that the middle part has already been fetched so
      we don't optimize that case.  kiss.  */
-  int mask;
+  unsigned int mask;
   disassemble_info *info = (disassemble_info *) ex_info->dis_info;
 
   /* First do a quick check.  */
@@ -370,53 +377,24 @@ fill_cache (cd, ex_info, offset, bytes, pc)
 /* Subroutine of extract_normal.  */
 
 static CGEN_INLINE long
-extract_1 (cd, ex_info, start, length, word_length, bufp, pc)
-     CGEN_CPU_DESC cd;
-     CGEN_EXTRACT_INFO *ex_info;
-     int start,length,word_length;
-     unsigned char *bufp;
-     bfd_vma pc;
+extract_1 (CGEN_CPU_DESC cd,
+	   CGEN_EXTRACT_INFO *ex_info ATTRIBUTE_UNUSED,
+	   int start,
+	   int length,
+	   int word_length,
+	   unsigned char *bufp,
+	   bfd_vma pc ATTRIBUTE_UNUSED)
 {
-  unsigned long x,mask;
+  unsigned long x;
   int shift;
-  int big_p = CGEN_CPU_INSN_ENDIAN (cd) == CGEN_ENDIAN_BIG;
 
-  switch (word_length)
-    {
-    case 8:
-      x = *bufp;
-      break;
-    case 16:
-      if (big_p)
-	x = bfd_getb16 (bufp);
-      else
-	x = bfd_getl16 (bufp);
-      break;
-    case 24:
-      /* ??? This may need reworking as these cases don't necessarily
-	 want the first byte and the last two bytes handled like this.  */
-      if (big_p)
-	x = (bufp[0] << 16) | bfd_getb16 (bufp + 1);
-      else
-	x = bfd_getl16 (bufp) | (bufp[2] << 16);
-      break;
-    case 32:
-      if (big_p)
-	x = bfd_getb32 (bufp);
-      else
-	x = bfd_getl32 (bufp);
-      break;
-    default :
-      abort ();
-    }
+  x = cgen_get_insn_value (cd, bufp, word_length);
 
-  /* Written this way to avoid undefined behaviour.  */
-  mask = (((1L << (length - 1)) - 1) << 1) | 1;
   if (CGEN_INSN_LSB0_P)
     shift = (start + 1) - length;
   else
     shift = (word_length - (start + length));
-  return (x >> shift) & mask;
+  return x >> shift;
 }
 
 #endif /* ! CGEN_INT_INSN_P */
@@ -442,17 +420,27 @@ extract_1 (cd, ex_info, start, length, word_length, bufp, pc)
    necessary.  */
 
 static int
-extract_normal (cd, ex_info, insn_value, attrs, word_offset, start, length,
-		word_length, total_length, pc, valuep)
-     CGEN_CPU_DESC cd;
-     CGEN_EXTRACT_INFO *ex_info;
-     CGEN_INSN_INT insn_value;
-     unsigned int attrs;
-     unsigned int word_offset, start, length, word_length, total_length;
-     bfd_vma pc;
-     long *valuep;
+extract_normal (CGEN_CPU_DESC cd,
+#if ! CGEN_INT_INSN_P
+		CGEN_EXTRACT_INFO *ex_info,
+#else
+		CGEN_EXTRACT_INFO *ex_info ATTRIBUTE_UNUSED,
+#endif
+		CGEN_INSN_INT insn_value,
+		unsigned int attrs,
+		unsigned int word_offset,
+		unsigned int start,
+		unsigned int length,
+		unsigned int word_length,
+		unsigned int total_length,
+#if ! CGEN_INT_INSN_P
+		bfd_vma pc,
+#else
+		bfd_vma pc ATTRIBUTE_UNUSED,
+#endif
+		long *valuep)
 {
-  CGEN_INSN_INT value;
+  long value, mask;
 
   /* If LENGTH is zero, this operand doesn't contribute to the value
      so give it a standard value of zero.  */
@@ -462,38 +450,25 @@ extract_normal (cd, ex_info, insn_value, attrs, word_offset, start, length,
       return 1;
     }
 
-  if (CGEN_INT_INSN_P
-      && word_offset != 0)
-    abort ();
-
-  if (word_length > 32)
+  if (word_length > 8 * sizeof (CGEN_INSN_INT))
     abort ();
 
   /* For architectures with insns smaller than the insn-base-bitsize,
      word_length may be too big.  */
   if (cd->min_insn_bitsize < cd->base_insn_bitsize)
     {
-      if (word_offset == 0
-	  && word_length > total_length)
-	word_length = total_length;
+      if (word_offset + word_length > total_length)
+	word_length = total_length - word_offset;
     }
 
-  /* Does the value reside in INSN_VALUE?  */
+  /* Does the value reside in INSN_VALUE, and at the right alignment?  */
 
-  if (word_offset == 0)
+  if (CGEN_INT_INSN_P || (word_offset == 0 && word_length == total_length))
     {
-      /* Written this way to avoid undefined behaviour.  */
-      CGEN_INSN_INT mask = (((1L << (length - 1)) - 1) << 1) | 1;
-
       if (CGEN_INSN_LSB0_P)
-	value = insn_value >> ((start + 1) - length);
+	value = insn_value >> ((word_offset + start + 1) - length);
       else
-	value = insn_value >> (word_length - (start + length));
-      value &= mask;
-      /* sign extend? */
-      if (CGEN_BOOL_ATTR (attrs, CGEN_IFLD_SIGNED)
-	  && (value & (1L << (length - 1))))
-	value |= ~mask;
+	value = insn_value >> (total_length - ( word_offset + start + length));
     }
 
 #if ! CGEN_INT_INSN_P
@@ -502,7 +477,7 @@ extract_normal (cd, ex_info, insn_value, attrs, word_offset, start, length,
     {
       unsigned char *bufp = ex_info->insn_bytes + word_offset / 8;
 
-      if (word_length > 32)
+      if (word_length > 8 * sizeof (CGEN_INSN_INT))
 	abort ();
 
       if (fill_cache (cd, ex_info, word_offset / 8, word_length / 8, pc) == 0)
@@ -512,6 +487,15 @@ extract_normal (cd, ex_info, insn_value, attrs, word_offset, start, length,
     }
 
 #endif /* ! CGEN_INT_INSN_P */
+
+  /* Written this way to avoid undefined behaviour.  */
+  mask = (((1L << (length - 1)) - 1) << 1) | 1;
+
+  value &= mask;
+  /* sign extend? */
+  if (CGEN_BOOL_ATTR (attrs, CGEN_IFLD_SIGNED)
+      && (value & (1L << (length - 1))))
+    value |= ~mask;
 
   *valuep = value;
 
@@ -528,16 +512,15 @@ extract_normal (cd, ex_info, insn_value, attrs, word_offset, start, length,
    been called).  */
 
 static int
-extract_insn_normal (cd, insn, ex_info, insn_value, fields, pc)
-     CGEN_CPU_DESC cd;
-     const CGEN_INSN *insn;
-     CGEN_EXTRACT_INFO *ex_info;
-     CGEN_INSN_INT insn_value;
-     CGEN_FIELDS *fields;
-     bfd_vma pc;
+extract_insn_normal (CGEN_CPU_DESC cd,
+		     const CGEN_INSN *insn,
+		     CGEN_EXTRACT_INFO *ex_info,
+		     CGEN_INSN_INT insn_value,
+		     CGEN_FIELDS *fields,
+		     bfd_vma pc)
 {
   const CGEN_SYNTAX *syntax = CGEN_INSN_SYNTAX (insn);
-  const unsigned char *syn;
+  const CGEN_SYNTAX_CHAR_TYPE *syn;
 
   CGEN_FIELDS_BITSIZE (fields) = CGEN_INSN_BITSIZE (insn);
 
@@ -560,7 +543,10 @@ extract_insn_normal (cd, insn, ex_info, insn_value, fields, pc)
   return CGEN_INSN_BITSIZE (insn);
 }
 
-/* machine generated code added here */
+/* Machine generated code added here.  */
+
+const char * nios_cgen_insert_operand
+  (CGEN_CPU_DESC, int, CGEN_FIELDS *, CGEN_INSN_BYTES_PTR, bfd_vma);
 
 /* Main entry point for operand insertion.
 
@@ -574,16 +560,14 @@ extract_insn_normal (cd, insn, ex_info, insn_value, fields, pc)
    This function could be moved into `parse_insn_normal', but keeping it
    separate makes clear the interface between `parse_insn_normal' and each of
    the handlers.  It's also needed by GAS to insert operands that couldn't be
-   resolved during parsing.
-*/
+   resolved during parsing.  */
 
 const char *
-nios_cgen_insert_operand (cd, opindex, fields, buffer, pc)
-     CGEN_CPU_DESC cd;
-     int opindex;
-     CGEN_FIELDS * fields;
-     CGEN_INSN_BYTES_PTR buffer;
-     bfd_vma pc;
+nios_cgen_insert_operand (CGEN_CPU_DESC cd,
+			     int opindex,
+			     CGEN_FIELDS * fields,
+			     CGEN_INSN_BYTES_PTR buffer,
+			     bfd_vma pc ATTRIBUTE_UNUSED)
 {
   const char * errmsg = NULL;
   unsigned int total_length = CGEN_FIELDS_BITSIZE (fields);
@@ -731,13 +715,17 @@ nios_cgen_insert_operand (cd, opindex, fields, buffer, pc)
 
     default :
       /* xgettext:c-format */
-      fprintf (stderr, _("Unrecognized field %d while building insn.\n"),
-	       opindex);
+      opcodes_error_handler
+	(_("internal error: unrecognized field %d while building insn"),
+	 opindex);
       abort ();
   }
 
   return errmsg;
 }
+
+int nios_cgen_extract_operand
+  (CGEN_CPU_DESC, int, CGEN_EXTRACT_INFO *, CGEN_INSN_INT, CGEN_FIELDS *, bfd_vma);
 
 /* Main entry point for operand extraction.
    The result is <= 0 for error, >0 for success.
@@ -752,17 +740,15 @@ nios_cgen_insert_operand (cd, opindex, fields, buffer, pc)
 
    This function could be moved into `print_insn_normal', but keeping it
    separate makes clear the interface between `print_insn_normal' and each of
-   the handlers.
-*/
+   the handlers.  */
 
 int
-nios_cgen_extract_operand (cd, opindex, ex_info, insn_value, fields, pc)
-     CGEN_CPU_DESC cd;
-     int opindex;
-     CGEN_EXTRACT_INFO *ex_info;
-     CGEN_INSN_INT insn_value;
-     CGEN_FIELDS * fields;
-     bfd_vma pc;
+nios_cgen_extract_operand (CGEN_CPU_DESC cd,
+			     int opindex,
+			     CGEN_EXTRACT_INFO *ex_info,
+			     CGEN_INSN_INT insn_value,
+			     CGEN_FIELDS * fields,
+			     bfd_vma pc)
 {
   /* Assume success (for those operands that are nops).  */
   int length = 1;
@@ -936,16 +922,18 @@ cgen_extract_fn * const nios_cgen_extract_handlers[] =
   extract_insn_normal,
 };
 
+int nios_cgen_get_int_operand     (CGEN_CPU_DESC, int, const CGEN_FIELDS *);
+bfd_vma nios_cgen_get_vma_operand (CGEN_CPU_DESC, int, const CGEN_FIELDS *);
+
 /* Getting values from cgen_fields is handled by a collection of functions.
    They are distinguished by the type of the VALUE argument they return.
    TODO: floating point, inlining support, remove cases where result type
    not appropriate.  */
 
 int
-nios_cgen_get_int_operand (cd, opindex, fields)
-     CGEN_CPU_DESC cd;
-     int opindex;
-     const CGEN_FIELDS * fields;
+nios_cgen_get_int_operand (CGEN_CPU_DESC cd ATTRIBUTE_UNUSED,
+			     int opindex,
+			     const CGEN_FIELDS * fields)
 {
   int value;
 
@@ -1068,8 +1056,9 @@ nios_cgen_get_int_operand (cd, opindex, fields)
 
     default :
       /* xgettext:c-format */
-      fprintf (stderr, _("Unrecognized field %d while getting int operand.\n"),
-		       opindex);
+      opcodes_error_handler
+	(_("internal error: unrecognized field %d while getting int operand"),
+	 opindex);
       abort ();
   }
 
@@ -1077,10 +1066,9 @@ nios_cgen_get_int_operand (cd, opindex, fields)
 }
 
 bfd_vma
-nios_cgen_get_vma_operand (cd, opindex, fields)
-     CGEN_CPU_DESC cd;
-     int opindex;
-     const CGEN_FIELDS * fields;
+nios_cgen_get_vma_operand (CGEN_CPU_DESC cd ATTRIBUTE_UNUSED,
+			     int opindex,
+			     const CGEN_FIELDS * fields)
 {
   bfd_vma value;
 
@@ -1211,17 +1199,19 @@ nios_cgen_get_vma_operand (cd, opindex, fields)
   return value;
 }
 
+void nios_cgen_set_int_operand  (CGEN_CPU_DESC, int, CGEN_FIELDS *, int);
+void nios_cgen_set_vma_operand  (CGEN_CPU_DESC, int, CGEN_FIELDS *, bfd_vma);
+
 /* Stuffing values in cgen_fields is handled by a collection of functions.
    They are distinguished by the type of the VALUE argument they accept.
    TODO: floating point, inlining support, remove cases where argument type
    not appropriate.  */
 
 void
-nios_cgen_set_int_operand (cd, opindex, fields, value)
-     CGEN_CPU_DESC cd;
-     int opindex;
-     CGEN_FIELDS * fields;
-     int value;
+nios_cgen_set_int_operand (CGEN_CPU_DESC cd ATTRIBUTE_UNUSED,
+			     int opindex,
+			     CGEN_FIELDS * fields,
+			     int value)
 {
   switch (opindex)
     {
@@ -1338,18 +1328,18 @@ nios_cgen_set_int_operand (cd, opindex, fields, value)
 
     default :
       /* xgettext:c-format */
-      fprintf (stderr, _("Unrecognized field %d while setting int operand.\n"),
-		       opindex);
+      opcodes_error_handler
+	(_("internal error: unrecognized field %d while setting int operand"),
+	 opindex);
       abort ();
   }
 }
 
 void
-nios_cgen_set_vma_operand (cd, opindex, fields, value)
-     CGEN_CPU_DESC cd;
-     int opindex;
-     CGEN_FIELDS * fields;
-     bfd_vma value;
+nios_cgen_set_vma_operand (CGEN_CPU_DESC cd ATTRIBUTE_UNUSED,
+			     int opindex,
+			     CGEN_FIELDS * fields,
+			     bfd_vma value)
 {
   switch (opindex)
     {
@@ -1466,8 +1456,9 @@ nios_cgen_set_vma_operand (cd, opindex, fields, value)
 
     default :
       /* xgettext:c-format */
-      fprintf (stderr, _("Unrecognized field %d while setting vma operand.\n"),
-		       opindex);
+      opcodes_error_handler
+	(_("internal error: unrecognized field %d while setting vma operand"),
+	 opindex);
       abort ();
   }
 }
@@ -1475,8 +1466,7 @@ nios_cgen_set_vma_operand (cd, opindex, fields, value)
 /* Function to call before using the instruction builder tables.  */
 
 void
-nios_cgen_init_ibld_table (cd)
-     CGEN_CPU_DESC cd;
+nios_cgen_init_ibld_table (CGEN_CPU_DESC cd)
 {
   cd->insert_handlers = & nios_cgen_insert_handlers[0];
   cd->extract_handlers = & nios_cgen_extract_handlers[0];

--- a/libr/asm/arch/nios/gnu/nios-ibld.c
+++ b/libr/asm/arch/nios/gnu/nios-ibld.c
@@ -29,7 +29,8 @@ along with this program; if not, write to the Free Software Foundation, Inc.,
 #include <stdio.h>
 #include "ansidecl.h"
 #include "dis-asm.h"
-#include "bfd.h"
+//#include "bfd.h"
+#include "mybfd.h"
 #include "symcat.h"
 #include "nios-desc.h"
 #include "nios-opc.h"

--- a/libr/asm/arch/nios/gnu/nios-opc.c
+++ b/libr/asm/arch/nios/gnu/nios-opc.c
@@ -1,34 +1,32 @@
 /* Instruction opcode table for nios.
+   Copyright (C) 2012-2018 Free Software Foundation, Inc.
 
-THIS FILE IS MACHINE GENERATED WITH CGEN.
+   This file is part of the GNU opcodes library.
 
-Copyright (C) 1996, 1997, 1998, 1999, 2001 Free Software Foundation, Inc.
+   This library is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3, or (at your option)
+   any later version.
 
-This file is part of the GNU Binutils and/or GDB, the GNU debugger.
+   It is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+   License for more details.
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2, or (at your option)
-any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
-*/
+   You should have received a copy of the GNU General Public License
+   along with this file; see the file COPYING.  If not, write to the
+   Free Software Foundation, 51 Franklin Street - Fifth Floor, Boston,
+   MA 02110-1301, USA.  */
 
 #include "sysdep.h"
+#include <string.h>
 #include "ansidecl.h"
 //#include "bfd.h"
 #include "mybfd.h"
 #include "symcat.h"
 #include "nios-desc.h"
 #include "nios-opc.h"
+#include "libiberty.h"
 
 /* The hash functions are recorded here to help keep assembler code out of
    the disassembler and vice versa.  */
@@ -40,125 +38,124 @@ static unsigned int dis_hash_insn PARAMS ((const char *, CGEN_INSN_INT));
 
 /* Instruction formats.  */
 
-#define F(f) & nios_cgen_ifld_table[CONCAT2 (NIOS_,f)]
-
-static const CGEN_IFMT ifmt_empty = {
+#define F(f) & nios_cgen_ifld_table[NIOS_##f]
+static const CGEN_IFMT ifmt_empty ATTRIBUTE_UNUSED = {
   0, 0, 0x0, { { 0 } }
 };
 
-static const CGEN_IFMT ifmt_ext8s16 = {
+static const CGEN_IFMT ifmt_ext8s16 ATTRIBUTE_UNUSED = {
   16, 16, 0xff80, { { F (F_OP9) }, { F (F_I1) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_sts8s16 = {
+static const CGEN_IFMT ifmt_sts8s16 ATTRIBUTE_UNUSED = {
   16, 16, 0xfc00, { { F (F_OP6) }, { F (F_I10) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_st8d16 = {
+static const CGEN_IFMT ifmt_st8d16 ATTRIBUTE_UNUSED = {
   16, 16, 0xffe0, { { F (F_OP11) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_addc16 = {
+static const CGEN_IFMT ifmt_addc16 ATTRIBUTE_UNUSED = {
   16, 16, 0xfc00, { { F (F_OP6) }, { F (F_RB) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_addi16 = {
+static const CGEN_IFMT ifmt_addi16 ATTRIBUTE_UNUSED = {
   16, 16, 0xfc00, { { F (F_OP6) }, { F (F_I5) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_or16 = {
+static const CGEN_IFMT ifmt_or16 ATTRIBUTE_UNUSED = {
   16, 16, 0xfc00, { { F (F_OP6) }, { F (F_RBI5) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_lds16 = {
+static const CGEN_IFMT ifmt_lds16 ATTRIBUTE_UNUSED = {
   16, 16, 0xe000, { { F (F_OP3) }, { F (F_I8) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_ldp16 = {
+static const CGEN_IFMT ifmt_ldp16 ATTRIBUTE_UNUSED = {
   16, 16, 0xf000, { { F (F_OP4) }, { F (F_RP) }, { F (F_I5) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_trap16 = {
+static const CGEN_IFMT ifmt_trap16 ATTRIBUTE_UNUSED = {
   16, 16, 0xff00, { { F (F_OP8) }, { F (F_O2) }, { F (F_I6V) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_save16 = {
+static const CGEN_IFMT ifmt_save16 ATTRIBUTE_UNUSED = {
   16, 16, 0xff00, { { F (F_OP8) }, { F (F_I8V) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_restore16 = {
+static const CGEN_IFMT ifmt_restore16 ATTRIBUTE_UNUSED = {
   16, 16, 0xffe0, { { F (F_OP11) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_bsr16 = {
+static const CGEN_IFMT ifmt_bsr16 ATTRIBUTE_UNUSED = {
   16, 16, 0xf800, { { F (F_OP5) }, { F (F_I11_REL) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_bsrr16 = {
+static const CGEN_IFMT ifmt_bsrr16 ATTRIBUTE_UNUSED = {
   16, 16, 0xf800, { { F (F_OP5) }, { F (F_BSRR_I6_REL) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_jmpc16 = {
+static const CGEN_IFMT ifmt_jmpc16 ATTRIBUTE_UNUSED = {
   16, 16, 0xff00, { { F (F_OP8) }, { F (F_I8V_REL_H) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_skps16 = {
+static const CGEN_IFMT ifmt_skps16 ATTRIBUTE_UNUSED = {
   16, 16, 0xffe0, { { F (F_OP11) }, { F (F_X1) }, { F (F_I4W) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_sts16s = {
+static const CGEN_IFMT ifmt_sts16s ATTRIBUTE_UNUSED = {
   16, 16, 0xfc00, { { F (F_OP6) }, { F (F_I9) }, { F (F_O1) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_movhi = {
+static const CGEN_IFMT ifmt_movhi ATTRIBUTE_UNUSED = {
   16, 16, 0xfc00, { { F (F_OP6) }, { F (F_I5) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_ext16d = {
+static const CGEN_IFMT ifmt_ext16d ATTRIBUTE_UNUSED = {
   16, 16, 0xfc00, { { F (F_OP6) }, { F (F_RB) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_sext16 = {
+static const CGEN_IFMT ifmt_sext16 ATTRIBUTE_UNUSED = {
   16, 16, 0xffe0, { { F (F_OP11) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_ext8s32 = {
+static const CGEN_IFMT ifmt_ext8s32 ATTRIBUTE_UNUSED = {
   16, 16, 0xff80, { { F (F_OP9) }, { F (F_I2) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_ext16s = {
+static const CGEN_IFMT ifmt_ext16s ATTRIBUTE_UNUSED = {
   16, 16, 0xff80, { { F (F_OP9) }, { F (F_I1) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_or32 = {
+static const CGEN_IFMT ifmt_or32 ATTRIBUTE_UNUSED = {
   16, 16, 0xfc00, { { F (F_OP6) }, { F (F_RBI5) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_lds32 = {
+static const CGEN_IFMT ifmt_lds32 ATTRIBUTE_UNUSED = {
   16, 16, 0xe000, { { F (F_OP3) }, { F (F_I8) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_ldp32 = {
+static const CGEN_IFMT ifmt_ldp32 ATTRIBUTE_UNUSED = {
   16, 16, 0xf000, { { F (F_OP4) }, { F (F_RP) }, { F (F_I5) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_bsrr32 = {
+static const CGEN_IFMT ifmt_bsrr32 ATTRIBUTE_UNUSED = {
   16, 16, 0xf800, { { F (F_OP5) }, { F (F_BSRR_I6_REL) }, { F (F_RA) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_jmpc32 = {
+static const CGEN_IFMT ifmt_jmpc32 ATTRIBUTE_UNUSED = {
   16, 16, 0xff00, { { F (F_OP8) }, { F (F_I8V_REL_W) }, { 0 } }
 };
 
-static const CGEN_IFMT ifmt_pfx = {
+static const CGEN_IFMT ifmt_pfx ATTRIBUTE_UNUSED = {
   16, 16, 0xf800, { { F (F_OP5) }, { F (F_I11) }, { 0 } }
 };
 
 #undef F
 
-#define A(a) (1 << CONCAT2 (CGEN_INSN_,a))
+#define A(a) (1 << CGEN_INSN_##a)
 #define MNEM CGEN_SYNTAX_MNEMONIC /* syntax value for mnemonic */
-#define OPERAND(op) CONCAT2 (NIOS_OPERAND_,op)
+#define OPERAND(op) NIOS_OPERAND_##op
 #define OP(field) CGEN_SYNTAX_MAKE_FIELD (OPERAND (field))
 
 /* The instruction table.  */
@@ -982,7 +979,7 @@ static const CGEN_OPCODE nios_cgen_insn_opcode_table[MAX_INSNS] =
 
 /* Formats for ALIAS macro-insns.  */
 
-#define F(f) & nios_cgen_ifld_table[CONCAT2 (NIOS_,f)]
+#define F(f) & nios_cgen_ifld_table[NIOS_##f]
 
 static const CGEN_IFMT ifmt_if016 = {
   16, 16, 0xfc00, { { F (F_OP6) }, { F (F_RA) }, { F (F_I5) }, { 0 } }
@@ -1076,9 +1073,9 @@ static const CGEN_IFMT ifmt_lret32 = {
 
 /* Each non-simple macro entry points to an array of expansion possibilities.  */
 
-#define A(a) (1 << CONCAT2 (CGEN_INSN_,a))
+#define A(a) (1 << CGEN_INSN_##a)
 #define MNEM CGEN_SYNTAX_MNEMONIC /* syntax value for mnemonic */
-#define OPERAND(op) CONCAT2 (NIOS_OPERAND_,op)
+#define OPERAND(op) NIOS_OPERAND_##op
 #define OP(field) CGEN_SYNTAX_MAKE_FIELD (OPERAND (field))
 
 /* The macro instruction table.  */
@@ -1088,112 +1085,112 @@ static const CGEN_IBASE nios_cgen_macro_insn_table[] =
 /* if0 $m16_Ra,$i5 */
   {
     -1, "if016", "if0", 16,
-    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS16) } }
+    { 0|A(NO_DIS)|A(ALIAS), { { { (1<<MACH_NIOS16) } } } }
   },
 /* if1 $m16_Ra,$i5 */
   {
     -1, "if116", "if1", 16,
-    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS16) } }
+    { 0|A(NO_DIS)|A(ALIAS), { { { (1<<MACH_NIOS16) } } } }
   },
 /* ifrz $m16_Ra */
   {
     -1, "ifrz16", "ifrz", 16,
-    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS16) } }
+    { 0|A(NO_DIS)|A(ALIAS), { { { (1<<MACH_NIOS16) } } } }
   },
 /* ifrnz $m16_Ra */
   {
     -1, "ifrnz16", "ifrnz", 16,
-    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS16) } }
+    { 0|A(NO_DIS)|A(ALIAS), { { { (1<<MACH_NIOS16) } } } }
   },
 /* ifs $i4wn */
   {
     -1, "ifs16", "ifs", 16,
-    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS16) } }
+    { 0|A(NO_DIS)|A(ALIAS), { { { (1<<MACH_NIOS16) } } } }
   },
 /* nop */
   {
     -1, "nop16", "nop", 16,
-    { 0|A(ALIAS), { (1<<MACH_NIOS16) } }
+    { 0|A(ALIAS), { { { (1<<MACH_NIOS16) } } } }
   },
 /* inc $m16_Ra */
   {
     -1, "inc16", "inc", 16,
-    { 0|A(ALIAS), { (1<<MACH_NIOS16) } }
+    { 0|A(ALIAS), { { { (1<<MACH_NIOS16) } } } }
   },
 /* dec $m16_Ra */
   {
     -1, "dec16", "dec", 16,
-    { 0|A(ALIAS), { (1<<MACH_NIOS16) } }
+    { 0|A(ALIAS), { { { (1<<MACH_NIOS16) } } } }
   },
 /* clr $m16_Ra */
   {
     -1, "clr16", "clr", 16,
-    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS16) } }
+    { 0|A(NO_DIS)|A(ALIAS), { { { (1<<MACH_NIOS16) } } } }
   },
 /* ret */
   {
     -1, "ret16", "ret", 16,
-    { 0|A(ALIAS), { (1<<MACH_NIOS16) } }
+    { 0|A(ALIAS), { { { (1<<MACH_NIOS16) } } } }
   },
 /* lret */
   {
     -1, "lret16", "lret", 16,
-    { 0|A(ALIAS), { (1<<MACH_NIOS16) } }
+    { 0|A(ALIAS), { { { (1<<MACH_NIOS16) } } } }
   },
 /* if0 $m32_Ra,$i5 */
   {
     -1, "if032", "if0", 16,
-    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS32) } }
+    { 0|A(NO_DIS)|A(ALIAS), { { { (1<<MACH_NIOS32) } } } }
   },
 /* if1 $m32_Ra,$i5 */
   {
     -1, "if132", "if1", 16,
-    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS32) } }
+    { 0|A(NO_DIS)|A(ALIAS), { { { (1<<MACH_NIOS32) } } } }
   },
 /* ifrz $m32_Ra */
   {
     -1, "ifrz32", "ifrz", 16,
-    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS32) } }
+    { 0|A(NO_DIS)|A(ALIAS), { { { (1<<MACH_NIOS32) } } } }
   },
 /* ifrnz $m32_Ra */
   {
     -1, "ifrnz32", "ifrnz", 16,
-    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS32) } }
+    { 0|A(NO_DIS)|A(ALIAS), { { { (1<<MACH_NIOS32) } } } }
   },
 /* ifs $i4wn */
   {
     -1, "ifs32", "ifs", 16,
-    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS32) } }
+    { 0|A(NO_DIS)|A(ALIAS), { { { (1<<MACH_NIOS32) } } } }
   },
 /* nop */
   {
     -1, "nop32", "nop", 16,
-    { 0|A(ALIAS), { (1<<MACH_NIOS32) } }
+    { 0|A(ALIAS), { { { (1<<MACH_NIOS32) } } } }
   },
 /* inc $m32_Ra */
   {
     -1, "inc32", "inc", 16,
-    { 0|A(ALIAS), { (1<<MACH_NIOS32) } }
+    { 0|A(ALIAS), { { { (1<<MACH_NIOS32) } } } }
   },
 /* dec $m32_Ra */
   {
     -1, "dec32", "dec", 16,
-    { 0|A(ALIAS), { (1<<MACH_NIOS32) } }
+    { 0|A(ALIAS), { { { (1<<MACH_NIOS32) } } } }
   },
 /* clr $m32_Ra */
   {
     -1, "clr32", "clr", 16,
-    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS32) } }
+    { 0|A(NO_DIS)|A(ALIAS), { { { (1<<MACH_NIOS32) } } } }
   },
 /* ret */
   {
     -1, "ret32", "ret", 16,
-    { 0|A(ALIAS), { (1<<MACH_NIOS32) } }
+    { 0|A(ALIAS), { { { (1<<MACH_NIOS32) } } } }
   },
 /* lret */
   {
     -1, "lret32", "lret", 16,
-    { 0|A(ALIAS), { (1<<MACH_NIOS32) } }
+    { 0|A(ALIAS), { { { (1<<MACH_NIOS32) } } } }
   },
 };
 

--- a/libr/asm/arch/nios/gnu/nios-opc.c
+++ b/libr/asm/arch/nios/gnu/nios-opc.c
@@ -1,0 +1,1459 @@
+/* Instruction opcode table for nios.
+
+THIS FILE IS MACHINE GENERATED WITH CGEN.
+
+Copyright (C) 1996, 1997, 1998, 1999, 2001 Free Software Foundation, Inc.
+
+This file is part of the GNU Binutils and/or GDB, the GNU debugger.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#include "sysdep.h"
+#include "ansidecl.h"
+#include "bfd.h"
+#include "symcat.h"
+#include "nios-desc.h"
+#include "nios-opc.h"
+
+/* The hash functions are recorded here to help keep assembler code out of
+   the disassembler and vice versa.  */
+
+static int asm_hash_insn_p PARAMS ((const CGEN_INSN *));
+static unsigned int asm_hash_insn PARAMS ((const char *));
+static int dis_hash_insn_p PARAMS ((const CGEN_INSN *));
+static unsigned int dis_hash_insn PARAMS ((const char *, CGEN_INSN_INT));
+
+/* Instruction formats.  */
+
+#define F(f) & nios_cgen_ifld_table[CONCAT2 (NIOS_,f)]
+
+static const CGEN_IFMT ifmt_empty = {
+  0, 0, 0x0, { { 0 } }
+};
+
+static const CGEN_IFMT ifmt_ext8s16 = {
+  16, 16, 0xff80, { { F (F_OP9) }, { F (F_I1) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_sts8s16 = {
+  16, 16, 0xfc00, { { F (F_OP6) }, { F (F_I10) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_st8d16 = {
+  16, 16, 0xffe0, { { F (F_OP11) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_addc16 = {
+  16, 16, 0xfc00, { { F (F_OP6) }, { F (F_RB) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_addi16 = {
+  16, 16, 0xfc00, { { F (F_OP6) }, { F (F_I5) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_or16 = {
+  16, 16, 0xfc00, { { F (F_OP6) }, { F (F_RBI5) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_lds16 = {
+  16, 16, 0xe000, { { F (F_OP3) }, { F (F_I8) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_ldp16 = {
+  16, 16, 0xf000, { { F (F_OP4) }, { F (F_RP) }, { F (F_I5) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_trap16 = {
+  16, 16, 0xff00, { { F (F_OP8) }, { F (F_O2) }, { F (F_I6V) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_save16 = {
+  16, 16, 0xff00, { { F (F_OP8) }, { F (F_I8V) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_restore16 = {
+  16, 16, 0xffe0, { { F (F_OP11) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_bsr16 = {
+  16, 16, 0xf800, { { F (F_OP5) }, { F (F_I11_REL) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_bsrr16 = {
+  16, 16, 0xf800, { { F (F_OP5) }, { F (F_BSRR_I6_REL) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_jmpc16 = {
+  16, 16, 0xff00, { { F (F_OP8) }, { F (F_I8V_REL_H) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_skps16 = {
+  16, 16, 0xffe0, { { F (F_OP11) }, { F (F_X1) }, { F (F_I4W) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_sts16s = {
+  16, 16, 0xfc00, { { F (F_OP6) }, { F (F_I9) }, { F (F_O1) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_movhi = {
+  16, 16, 0xfc00, { { F (F_OP6) }, { F (F_I5) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_ext16d = {
+  16, 16, 0xfc00, { { F (F_OP6) }, { F (F_RB) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_sext16 = {
+  16, 16, 0xffe0, { { F (F_OP11) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_ext8s32 = {
+  16, 16, 0xff80, { { F (F_OP9) }, { F (F_I2) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_ext16s = {
+  16, 16, 0xff80, { { F (F_OP9) }, { F (F_I1) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_or32 = {
+  16, 16, 0xfc00, { { F (F_OP6) }, { F (F_RBI5) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_lds32 = {
+  16, 16, 0xe000, { { F (F_OP3) }, { F (F_I8) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_ldp32 = {
+  16, 16, 0xf000, { { F (F_OP4) }, { F (F_RP) }, { F (F_I5) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_bsrr32 = {
+  16, 16, 0xf800, { { F (F_OP5) }, { F (F_BSRR_I6_REL) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_jmpc32 = {
+  16, 16, 0xff00, { { F (F_OP8) }, { F (F_I8V_REL_W) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_pfx = {
+  16, 16, 0xf800, { { F (F_OP5) }, { F (F_I11) }, { 0 } }
+};
+
+#undef F
+
+#define A(a) (1 << CONCAT2 (CGEN_INSN_,a))
+#define MNEM CGEN_SYNTAX_MNEMONIC /* syntax value for mnemonic */
+#define OPERAND(op) CONCAT2 (NIOS_OPERAND_,op)
+#define OP(field) CGEN_SYNTAX_MAKE_FIELD (OPERAND (field))
+
+/* The instruction table.  */
+
+static const CGEN_OPCODE nios_cgen_insn_opcode_table[MAX_INSNS] =
+{
+  /* Special null first entry.
+     A `num' value of zero is thus invalid.
+     Also, the special `invalid' insn resides here.  */
+  { { 0 } },
+/* ext8s $m16_Ra,$i1 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (I1), 0 } },
+    & ifmt_ext8s16, { 0x7400 }
+  },
+/* st8s [$m16_Ra],$m16_R0,$i1 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M16_RA), ']', ',', OP (M16_R0), ',', OP (I1), 0 } },
+    & ifmt_ext8s16, { 0x7600 }
+  },
+/* sts8s [$m16_sp,$i10],$m16_R0 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M16_SP), ',', OP (I10), ']', ',', OP (M16_R0), 0 } },
+    & ifmt_sts8s16, { 0x6000 }
+  },
+/* st8d [$m16_Ra],$m16_R0 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M16_RA), ']', ',', OP (M16_R0), 0 } },
+    & ifmt_st8d16, { 0x7e00 }
+  },
+/* wrctl $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7f00 }
+  },
+/* addc $m16_Ra,$m16_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (M16_RB), 0 } },
+    & ifmt_addc16, { 0x6800 }
+  },
+/* subc $m16_Ra,$m16_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (M16_RB), 0 } },
+    & ifmt_addc16, { 0x6c00 }
+  },
+/* add $m16_Ra,$m16_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (M16_RB), 0 } },
+    & ifmt_addc16, { 0x0 }
+  },
+/* sub $m16_Ra,$m16_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (M16_RB), 0 } },
+    & ifmt_addc16, { 0x800 }
+  },
+/* addi $m16_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (I5), 0 } },
+    & ifmt_addi16, { 0x400 }
+  },
+/* subi $m16_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (I5), 0 } },
+    & ifmt_addi16, { 0xc00 }
+  },
+/* or $m16_Ra,$Rbi5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (RBI5), 0 } },
+    & ifmt_or16, { 0x4000 }
+  },
+/* xor $m16_Ra,$Rbi5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (RBI5), 0 } },
+    & ifmt_or16, { 0x4400 }
+  },
+/* and $m16_Ra,$Rbi5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (RBI5), 0 } },
+    & ifmt_or16, { 0x3800 }
+  },
+/* andn $m16_Ra,$Rbi5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (RBI5), 0 } },
+    & ifmt_or16, { 0x3c00 }
+  },
+/* lsl $m16_Ra,$m16_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (M16_RB), 0 } },
+    & ifmt_addc16, { 0x1800 }
+  },
+/* lsr $m16_Ra,$m16_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (M16_RB), 0 } },
+    & ifmt_addc16, { 0x2000 }
+  },
+/* asr $m16_Ra,$m16_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (M16_RB), 0 } },
+    & ifmt_addc16, { 0x2800 }
+  },
+/* lsli $m16_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (I5), 0 } },
+    & ifmt_addi16, { 0x1c00 }
+  },
+/* lsri $m16_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (I5), 0 } },
+    & ifmt_addi16, { 0x2400 }
+  },
+/* asri $m16_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (I5), 0 } },
+    & ifmt_addi16, { 0x2c00 }
+  },
+/* not $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7c00 }
+  },
+/* neg $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7c20 }
+  },
+/* abs $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7c40 }
+  },
+/* mov $m16_Ra,$m16_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (M16_RB), 0 } },
+    & ifmt_addc16, { 0x3000 }
+  },
+/* movi $m16_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (I5), 0 } },
+    & ifmt_addi16, { 0x3400 }
+  },
+/* bgen $m16_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (I5), 0 } },
+    & ifmt_addi16, { 0x4800 }
+  },
+/* cmp $m16_Ra,$m16_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (M16_RB), 0 } },
+    & ifmt_addc16, { 0x1000 }
+  },
+/* cmpi $m16_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (I5), 0 } },
+    & ifmt_addi16, { 0x1400 }
+  },
+/* ext8d $m16_Ra,$m16_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (M16_RB), 0 } },
+    & ifmt_addc16, { 0x4c00 }
+  },
+/* sext8 $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7c60 }
+  },
+/* fill8 $m16_R0,$m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_R0), ',', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7e40 }
+  },
+/* lds $m16_Ra,[$m16_sp,$i8] */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', '[', OP (M16_SP), ',', OP (I8), ']', 0 } },
+    & ifmt_lds16, { 0xe000 }
+  },
+/* sts [$m16_sp,$i8],$m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M16_SP), ',', OP (I8), ']', ',', OP (M16_RA), 0 } },
+    & ifmt_lds16, { 0xc000 }
+  },
+/* ldp $m16_Ra,[$m16_Rp,$i5] */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', '[', OP (M16_RP), ',', OP (I5), ']', 0 } },
+    & ifmt_ldp16, { 0xb000 }
+  },
+/* stp [$m16_Rp,$i5],$m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M16_RP), ',', OP (I5), ']', ',', OP (M16_RA), 0 } },
+    & ifmt_ldp16, { 0xa000 }
+  },
+/* ld $m16_Ra,[$m16_Rb] */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', '[', OP (M16_RB), ']', 0 } },
+    & ifmt_addc16, { 0x5800 }
+  },
+/* st [$m16_Rb],$m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M16_RB), ']', ',', OP (M16_RA), 0 } },
+    & ifmt_addc16, { 0x5c00 }
+  },
+/* trap $i6v */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (I6V), 0 } },
+    & ifmt_trap16, { 0x7900 }
+  },
+/* tret $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7dc0 }
+  },
+/* save $m16_sp,$save_i8v */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_SP), ',', OP (SAVE_I8V), 0 } },
+    & ifmt_save16, { 0x7800 }
+  },
+/* restore */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, 0 } },
+    & ifmt_restore16, { 0x7da0 }
+  },
+/* bsr $rel11 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (REL11), 0 } },
+    & ifmt_bsr16, { 0x8800 }
+  },
+/* bsrr $m16_Ra,$bsrr_rel6 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (BSRR_REL6), 0 } },
+    & ifmt_bsrr16, { 0x8800 }
+  },
+/* jmp $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7fc0 }
+  },
+/* call $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7fe0 }
+  },
+/* jmpc [$m16_i8v] */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M16_I8V), ']', 0 } },
+    & ifmt_jmpc16, { 0x7a00 }
+  },
+/* callc [$m16_i8v] */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M16_I8V), ']', 0 } },
+    & ifmt_jmpc16, { 0x7b00 }
+  },
+/* skp0 $m16_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (I5), 0 } },
+    & ifmt_addi16, { 0x5000 }
+  },
+/* skp1 $m16_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (I5), 0 } },
+    & ifmt_addi16, { 0x5400 }
+  },
+/* skprz $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7ec0 }
+  },
+/* skprnz $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7f40 }
+  },
+/* skps $i4w */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (I4W), 0 } },
+    & ifmt_skps16, { 0x7ee0 }
+  },
+/* rrc $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7cc0 }
+  },
+/* rlc $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7ca0 }
+  },
+/* rdctl $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7f20 }
+  },
+/* usr0 $m16_Ra, $m16_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (M16_RB), 0 } },
+    & ifmt_addc16, { 0x7000 }
+  },
+/* usr1 $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7d20 }
+  },
+/* usr2 $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7d40 }
+  },
+/* usr3 $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7d60 }
+  },
+/* usr4 $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_st8d16, { 0x7d80 }
+  },
+/* sts8s [$m32_sp,$i10],$m32_R0 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M32_SP), ',', OP (I10), ']', ',', OP (M32_R0), 0 } },
+    & ifmt_sts8s16, { 0x6000 }
+  },
+/* sts16s [$m32_sp,$i9],$m32_R0 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M32_SP), ',', OP (I9), ']', ',', OP (M32_R0), 0 } },
+    & ifmt_sts16s, { 0x6400 }
+  },
+/* movhi $m32_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I5), 0 } },
+    & ifmt_movhi, { 0x6c00 }
+  },
+/* ext16d $m32_Ra,$m32_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (M32_RB), 0 } },
+    & ifmt_ext16d, { 0x6800 }
+  },
+/* sext16 $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7c80 }
+  },
+/* st16d [$m32_Ra],$m32_R0 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M32_RA), ']', ',', OP (M32_R0), 0 } },
+    & ifmt_sext16, { 0x7e20 }
+  },
+/* fill16 $m32_R0,$m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_R0), ',', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7e60 }
+  },
+/* ext8s $m32_Ra,$i2 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I2), 0 } },
+    & ifmt_ext8s32, { 0x7400 }
+  },
+/* st8s [$m32_Ra],$m32_R0,$i2 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M32_RA), ']', ',', OP (M32_R0), ',', OP (I2), 0 } },
+    & ifmt_ext8s32, { 0x7600 }
+  },
+/* ext16s $m32_Ra,$i1 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I1), 0 } },
+    & ifmt_ext16s, { 0x7480 }
+  },
+/* st16s [$m32_Ra],$m32_R0,$i1 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M32_RA), ']', ',', OP (M32_R0), ',', OP (I1), 0 } },
+    & ifmt_ext16s, { 0x7680 }
+  },
+/* st8d [$m32_Ra],$m32_R0 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M32_RA), ']', ',', OP (M32_R0), 0 } },
+    & ifmt_sext16, { 0x7e00 }
+  },
+/* wrctl $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7f00 }
+  },
+/* add $m32_Ra,$m32_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (M32_RB), 0 } },
+    & ifmt_ext16d, { 0x0 }
+  },
+/* sub $m32_Ra,$m32_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (M32_RB), 0 } },
+    & ifmt_ext16d, { 0x800 }
+  },
+/* addi $m32_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I5), 0 } },
+    & ifmt_movhi, { 0x400 }
+  },
+/* subi $m32_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I5), 0 } },
+    & ifmt_movhi, { 0xc00 }
+  },
+/* or $m32_Ra,$Rbi5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (RBI5), 0 } },
+    & ifmt_or32, { 0x4000 }
+  },
+/* xor $m32_Ra,$Rbi5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (RBI5), 0 } },
+    & ifmt_or32, { 0x4400 }
+  },
+/* and $m32_Ra,$Rbi5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (RBI5), 0 } },
+    & ifmt_or32, { 0x3800 }
+  },
+/* andn $m32_Ra,$Rbi5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (RBI5), 0 } },
+    & ifmt_or32, { 0x3c00 }
+  },
+/* lsl $m32_Ra,$m32_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (M32_RB), 0 } },
+    & ifmt_ext16d, { 0x1800 }
+  },
+/* lsr $m32_Ra,$m32_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (M32_RB), 0 } },
+    & ifmt_ext16d, { 0x2000 }
+  },
+/* asr $m32_Ra,$m32_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (M32_RB), 0 } },
+    & ifmt_ext16d, { 0x2800 }
+  },
+/* lsli $m32_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I5), 0 } },
+    & ifmt_movhi, { 0x1c00 }
+  },
+/* lsri $m32_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I5), 0 } },
+    & ifmt_movhi, { 0x2400 }
+  },
+/* asri $m32_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I5), 0 } },
+    & ifmt_movhi, { 0x2c00 }
+  },
+/* not $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7c00 }
+  },
+/* neg $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7c20 }
+  },
+/* abs $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7c40 }
+  },
+/* mov $m32_Ra,$m32_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (M32_RB), 0 } },
+    & ifmt_ext16d, { 0x3000 }
+  },
+/* movi $m32_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I5), 0 } },
+    & ifmt_movhi, { 0x3400 }
+  },
+/* bgen $m32_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I5), 0 } },
+    & ifmt_movhi, { 0x4800 }
+  },
+/* cmp $m32_Ra,$m32_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (M32_RB), 0 } },
+    & ifmt_ext16d, { 0x1000 }
+  },
+/* cmpi $m32_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I5), 0 } },
+    & ifmt_movhi, { 0x1400 }
+  },
+/* ext8d $m32_Ra,$m32_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (M32_RB), 0 } },
+    & ifmt_ext16d, { 0x4c00 }
+  },
+/* sext8 $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7c60 }
+  },
+/* fill8 $m32_R0,$m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_R0), ',', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7e40 }
+  },
+/* lds $m32_Ra,[$m32_sp,$i8] */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', '[', OP (M32_SP), ',', OP (I8), ']', 0 } },
+    & ifmt_lds32, { 0xe000 }
+  },
+/* sts [$m32_sp,$i8],$m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M32_SP), ',', OP (I8), ']', ',', OP (M32_RA), 0 } },
+    & ifmt_lds32, { 0xc000 }
+  },
+/* ldp $m32_Ra,[$m32_Rp,$i5] */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', '[', OP (M32_RP), ',', OP (I5), ']', 0 } },
+    & ifmt_ldp32, { 0xb000 }
+  },
+/* stp [$m32_Rp,$i5],$m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M32_RP), ',', OP (I5), ']', ',', OP (M32_RA), 0 } },
+    & ifmt_ldp32, { 0xa000 }
+  },
+/* ld $m32_Ra,[$m32_Rb] */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', '[', OP (M32_RB), ']', 0 } },
+    & ifmt_ext16d, { 0x5800 }
+  },
+/* st [$m32_Rb],$m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M32_RB), ']', ',', OP (M32_RA), 0 } },
+    & ifmt_ext16d, { 0x5c00 }
+  },
+/* trap $i6v */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (I6V), 0 } },
+    & ifmt_trap16, { 0x7900 }
+  },
+/* tret $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7dc0 }
+  },
+/* save $m32_sp,$save_i8v */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_SP), ',', OP (SAVE_I8V), 0 } },
+    & ifmt_save16, { 0x7800 }
+  },
+/* restore */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, 0 } },
+    & ifmt_restore16, { 0x7da0 }
+  },
+/* bsr $rel11 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (REL11), 0 } },
+    & ifmt_bsr16, { 0x8800 }
+  },
+/* bsrr $m32_Ra,$bsrr_rel6 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (BSRR_REL6), 0 } },
+    & ifmt_bsrr32, { 0x8800 }
+  },
+/* jmp $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7fc0 }
+  },
+/* call $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7fe0 }
+  },
+/* jmpc [$m32_i8v] */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M32_I8V), ']', 0 } },
+    & ifmt_jmpc32, { 0x7a00 }
+  },
+/* callc [$m32_i8v] */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', '[', OP (M32_I8V), ']', 0 } },
+    & ifmt_jmpc32, { 0x7b00 }
+  },
+/* skp0 $m32_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I5), 0 } },
+    & ifmt_movhi, { 0x5000 }
+  },
+/* skp1 $m32_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I5), 0 } },
+    & ifmt_movhi, { 0x5400 }
+  },
+/* skprz $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7ec0 }
+  },
+/* skprnz $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7f40 }
+  },
+/* skps $i4w */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (I4W), 0 } },
+    & ifmt_skps16, { 0x7ee0 }
+  },
+/* rrc $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7cc0 }
+  },
+/* rlc $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7ca0 }
+  },
+/* rdctl $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7f20 }
+  },
+/* pfx $i11 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (I11), 0 } },
+    & ifmt_pfx, { 0x9800 }
+  },
+/* br $rel11 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (REL11), 0 } },
+    & ifmt_bsr16, { 0x8000 }
+  },
+/* swap $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7d00 }
+  },
+/* mstep $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7e80 }
+  },
+/* mul $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7ea0 }
+  },
+/* usr0 $m32_Ra,$m32_Rb */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (M32_RB), 0 } },
+    & ifmt_ext16d, { 0x7000 }
+  },
+/* usr1 $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7d20 }  
+  },
+/* usr2 $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7d40 }  
+  },
+/* usr3 $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7d60 }  
+  },
+/* usr4 $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_sext16, { 0x7d80 }  
+  },
+/* pfxio $i11 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (I11), 0 } },
+    & ifmt_pfx, { 0x9000 }
+  },
+};
+
+#undef A
+#undef MNEM
+#undef OPERAND
+#undef OP
+
+/* Formats for ALIAS macro-insns.  */
+
+#define F(f) & nios_cgen_ifld_table[CONCAT2 (NIOS_,f)]
+
+static const CGEN_IFMT ifmt_if016 = {
+  16, 16, 0xfc00, { { F (F_OP6) }, { F (F_RA) }, { F (F_I5) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_if116 = {
+  16, 16, 0xfc00, { { F (F_OP6) }, { F (F_RA) }, { F (F_I5) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_ifrz16 = {
+  16, 16, 0xffe0, { { F (F_OP11) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_ifrnz16 = {
+  16, 16, 0xffe0, { { F (F_OP11) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_ifs16 = {
+  16, 16, 0xfff0, { { F (F_OP11) }, { F (F_X1) }, { F (F_I4W) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_nop16 = {
+  16, 16, 0xffff, { { F (F_OP6) }, { F (F_RA) }, { F (F_RB) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_inc16 = {
+  16, 16, 0xffe0, { { F (F_OP6) }, { F (F_RA) }, { F (F_I5) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_dec16 = {
+  16, 16, 0xffe0, { { F (F_OP6) }, { F (F_RA) }, { F (F_I5) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_clr16 = {
+  16, 16, 0xffe0, { { F (F_OP6) }, { F (F_RA) }, { F (F_I5) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_ret16 = {
+  16, 16, 0xffff, { { F (F_OP11) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_lret16 = {
+  16, 16, 0xffff, { { F (F_OP11) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_if032 = {
+  16, 16, 0xfc00, { { F (F_OP6) }, { F (F_RA) }, { F (F_I5) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_if132 = {
+  16, 16, 0xfc00, { { F (F_OP6) }, { F (F_RA) }, { F (F_I5) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_ifrz32 = {
+  16, 16, 0xffe0, { { F (F_OP11) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_ifrnz32 = {
+  16, 16, 0xffe0, { { F (F_OP11) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_ifs32 = {
+  16, 16, 0xfff0, { { F (F_OP11) }, { F (F_X1) }, { F (F_I4W) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_nop32 = {
+  16, 16, 0xffff, { { F (F_OP6) }, { F (F_RA) }, { F (F_RB) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_inc32 = {
+  16, 16, 0xffe0, { { F (F_OP6) }, { F (F_RA) }, { F (F_I5) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_dec32 = {
+  16, 16, 0xffe0, { { F (F_OP6) }, { F (F_RA) }, { F (F_I5) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_clr32 = {
+  16, 16, 0xffe0, { { F (F_OP6) }, { F (F_RA) }, { F (F_I5) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_ret32 = {
+  16, 16, 0xffff, { { F (F_OP11) }, { F (F_RA) }, { 0 } }
+};
+
+static const CGEN_IFMT ifmt_lret32 = {
+  16, 16, 0xffff, { { F (F_OP11) }, { F (F_RA) }, { 0 } }
+};
+
+#undef F
+
+/* Each non-simple macro entry points to an array of expansion possibilities.  */
+
+#define A(a) (1 << CONCAT2 (CGEN_INSN_,a))
+#define MNEM CGEN_SYNTAX_MNEMONIC /* syntax value for mnemonic */
+#define OPERAND(op) CONCAT2 (NIOS_OPERAND_,op)
+#define OP(field) CGEN_SYNTAX_MAKE_FIELD (OPERAND (field))
+
+/* The macro instruction table.  */
+
+static const CGEN_IBASE nios_cgen_macro_insn_table[] =
+{
+/* if0 $m16_Ra,$i5 */
+  {
+    -1, "if016", "if0", 16,
+    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS16) } }
+  },
+/* if1 $m16_Ra,$i5 */
+  {
+    -1, "if116", "if1", 16,
+    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS16) } }
+  },
+/* ifrz $m16_Ra */
+  {
+    -1, "ifrz16", "ifrz", 16,
+    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS16) } }
+  },
+/* ifrnz $m16_Ra */
+  {
+    -1, "ifrnz16", "ifrnz", 16,
+    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS16) } }
+  },
+/* ifs $i4wn */
+  {
+    -1, "ifs16", "ifs", 16,
+    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS16) } }
+  },
+/* nop */
+  {
+    -1, "nop16", "nop", 16,
+    { 0|A(ALIAS), { (1<<MACH_NIOS16) } }
+  },
+/* inc $m16_Ra */
+  {
+    -1, "inc16", "inc", 16,
+    { 0|A(ALIAS), { (1<<MACH_NIOS16) } }
+  },
+/* dec $m16_Ra */
+  {
+    -1, "dec16", "dec", 16,
+    { 0|A(ALIAS), { (1<<MACH_NIOS16) } }
+  },
+/* clr $m16_Ra */
+  {
+    -1, "clr16", "clr", 16,
+    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS16) } }
+  },
+/* ret */
+  {
+    -1, "ret16", "ret", 16,
+    { 0|A(ALIAS), { (1<<MACH_NIOS16) } }
+  },
+/* lret */
+  {
+    -1, "lret16", "lret", 16,
+    { 0|A(ALIAS), { (1<<MACH_NIOS16) } }
+  },
+/* if0 $m32_Ra,$i5 */
+  {
+    -1, "if032", "if0", 16,
+    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS32) } }
+  },
+/* if1 $m32_Ra,$i5 */
+  {
+    -1, "if132", "if1", 16,
+    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS32) } }
+  },
+/* ifrz $m32_Ra */
+  {
+    -1, "ifrz32", "ifrz", 16,
+    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS32) } }
+  },
+/* ifrnz $m32_Ra */
+  {
+    -1, "ifrnz32", "ifrnz", 16,
+    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS32) } }
+  },
+/* ifs $i4wn */
+  {
+    -1, "ifs32", "ifs", 16,
+    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS32) } }
+  },
+/* nop */
+  {
+    -1, "nop32", "nop", 16,
+    { 0|A(ALIAS), { (1<<MACH_NIOS32) } }
+  },
+/* inc $m32_Ra */
+  {
+    -1, "inc32", "inc", 16,
+    { 0|A(ALIAS), { (1<<MACH_NIOS32) } }
+  },
+/* dec $m32_Ra */
+  {
+    -1, "dec32", "dec", 16,
+    { 0|A(ALIAS), { (1<<MACH_NIOS32) } }
+  },
+/* clr $m32_Ra */
+  {
+    -1, "clr32", "clr", 16,
+    { 0|A(NO_DIS)|A(ALIAS), { (1<<MACH_NIOS32) } }
+  },
+/* ret */
+  {
+    -1, "ret32", "ret", 16,
+    { 0|A(ALIAS), { (1<<MACH_NIOS32) } }
+  },
+/* lret */
+  {
+    -1, "lret32", "lret", 16,
+    { 0|A(ALIAS), { (1<<MACH_NIOS32) } }
+  },
+};
+
+/* The macro instruction opcode table.  */
+
+static const CGEN_OPCODE nios_cgen_macro_insn_opcode_table[] =
+{
+/* if0 $m16_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (I5), 0 } },
+    & ifmt_if016, { 0x5400 }
+  },
+/* if1 $m16_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), ',', OP (I5), 0 } },
+    & ifmt_if116, { 0x5000 }
+  },
+/* ifrz $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_ifrz16, { 0x7f40 }
+  },
+/* ifrnz $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_ifrnz16, { 0x7ec0 }
+  },
+/* ifs $i4wn */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (I4WN), 0 } },
+    & ifmt_ifs16, { 0x7ee0 }
+  },
+/* nop */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, 0 } },
+    & ifmt_nop16, { 0x3000 }
+  },
+/* inc $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_inc16, { 0x420 }
+  },
+/* dec $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_dec16, { 0xc20 }
+  },
+/* clr $m16_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M16_RA), 0 } },
+    & ifmt_clr16, { 0x3400 }
+  },
+/* ret */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, 0 } },
+    & ifmt_ret16, { 0x7fdf }
+  },
+/* lret */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, 0 } },
+    & ifmt_lret16, { 0x7fcf }
+  },
+/* if0 $m32_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I5), 0 } },
+    & ifmt_if032, { 0x5400 }
+  },
+/* if1 $m32_Ra,$i5 */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), ',', OP (I5), 0 } },
+    & ifmt_if132, { 0x5000 }
+  },
+/* ifrz $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_ifrz32, { 0x7f40 }
+  },
+/* ifrnz $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_ifrnz32, { 0x7ec0 }
+  },
+/* ifs $i4wn */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (I4WN), 0 } },
+    & ifmt_ifs32, { 0x7ee0 }
+  },
+/* nop */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, 0 } },
+    & ifmt_nop32, { 0x3000 }
+  },
+/* inc $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_inc32, { 0x420 }
+  },
+/* dec $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_dec32, { 0xc20 }
+  },
+/* clr $m32_Ra */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, ' ', OP (M32_RA), 0 } },
+    & ifmt_clr32, { 0x3400 }
+  },
+/* ret */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, 0 } },
+    & ifmt_ret32, { 0x7fdf }
+  },
+/* lret */
+  {
+    { 0, 0, 0, 0 },
+    { { MNEM, 0 } },
+    & ifmt_lret32, { 0x7fcf }
+  },
+};
+
+#undef A
+#undef MNEM
+#undef OPERAND
+#undef OP
+
+#ifndef CGEN_ASM_HASH_P
+#define CGEN_ASM_HASH_P(insn) 1
+#endif
+
+#ifndef CGEN_DIS_HASH_P
+#define CGEN_DIS_HASH_P(insn) 1
+#endif
+
+/* Return non-zero if INSN is to be added to the hash table.
+   Targets are free to override CGEN_{ASM,DIS}_HASH_P in the .opc file.  */
+
+static int
+asm_hash_insn_p (insn)
+     const CGEN_INSN *insn;
+{
+  return CGEN_ASM_HASH_P (insn);
+}
+
+static int
+dis_hash_insn_p (insn)
+     const CGEN_INSN *insn;
+{
+  /* If building the hash table and the NO-DIS attribute is present,
+     ignore.  */
+  if (CGEN_INSN_ATTR_VALUE (insn, CGEN_INSN_NO_DIS))
+    return 0;
+  return CGEN_DIS_HASH_P (insn);
+}
+
+#ifndef CGEN_ASM_HASH
+#define CGEN_ASM_HASH_SIZE 127
+#ifdef CGEN_MNEMONIC_OPERANDS
+#define CGEN_ASM_HASH(mnem) (*(unsigned char *) (mnem) % CGEN_ASM_HASH_SIZE)
+#else
+#define CGEN_ASM_HASH(mnem) (*(unsigned char *) (mnem) % CGEN_ASM_HASH_SIZE) /*FIXME*/
+#endif
+#endif
+
+/* It doesn't make much sense to provide a default here,
+   but while this is under development we do.
+   BUFFER is a pointer to the bytes of the insn, target order.
+   VALUE is the first base_insn_bitsize bits as an int in host order.  */
+
+#ifndef CGEN_DIS_HASH
+#define CGEN_DIS_HASH_SIZE 256
+#define CGEN_DIS_HASH(buf, value) (*(unsigned char *) (buf))
+#endif
+
+/* The result is the hash value of the insn.
+   Targets are free to override CGEN_{ASM,DIS}_HASH in the .opc file.  */
+
+static unsigned int
+asm_hash_insn (mnem)
+     const char * mnem;
+{
+  return CGEN_ASM_HASH (mnem);
+}
+
+/* BUF is a pointer to the bytes of the insn, target order.
+   VALUE is the first base_insn_bitsize bits as an int in host order.  */
+
+static unsigned int
+dis_hash_insn (buf, value)
+     const char * buf;
+     CGEN_INSN_INT value;
+{
+  return CGEN_DIS_HASH (buf, value);
+}
+
+/* Set the recorded length of the insn in the CGEN_FIELDS struct.  */
+
+static void
+set_fields_bitsize (fields, size)
+     CGEN_FIELDS *fields;
+     int size;
+{
+  CGEN_FIELDS_BITSIZE (fields) = size;
+}
+
+/* Function to call before using the operand instance table.
+   This plugs the opcode entries and macro instructions into the cpu table.  */
+
+void
+nios_cgen_init_opcode_table (cd)
+     CGEN_CPU_DESC cd;
+{
+  int i;
+  int num_macros = (sizeof (nios_cgen_macro_insn_table) /
+		    sizeof (nios_cgen_macro_insn_table[0]));
+  const CGEN_IBASE *ib = & nios_cgen_macro_insn_table[0];
+  const CGEN_OPCODE *oc = & nios_cgen_macro_insn_opcode_table[0];
+  CGEN_INSN *insns = (CGEN_INSN *) xmalloc (num_macros * sizeof (CGEN_INSN));
+  memset (insns, 0, num_macros * sizeof (CGEN_INSN));
+  for (i = 0; i < num_macros; ++i)
+    {
+      insns[i].base = &ib[i];
+      insns[i].opcode = &oc[i];
+    }
+  cd->macro_insn_table.init_entries = insns;
+  cd->macro_insn_table.entry_size = sizeof (CGEN_IBASE);
+  cd->macro_insn_table.num_init_entries = num_macros;
+
+  oc = & nios_cgen_insn_opcode_table[0];
+  insns = (CGEN_INSN *) cd->insn_table.init_entries;
+  for (i = 0; i < MAX_INSNS; ++i)
+    insns[i].opcode = &oc[i];
+
+  cd->sizeof_fields = sizeof (CGEN_FIELDS);
+  cd->set_fields_bitsize = set_fields_bitsize;
+
+  cd->asm_hash_p = asm_hash_insn_p;
+  cd->asm_hash = asm_hash_insn;
+  cd->asm_hash_size = CGEN_ASM_HASH_SIZE;
+
+  cd->dis_hash_p = dis_hash_insn_p;
+  cd->dis_hash = dis_hash_insn;
+  cd->dis_hash_size = CGEN_DIS_HASH_SIZE;
+}

--- a/libr/asm/arch/nios/gnu/nios-opc.c
+++ b/libr/asm/arch/nios/gnu/nios-opc.c
@@ -24,7 +24,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "sysdep.h"
 #include "ansidecl.h"
-#include "bfd.h"
+//#include "bfd.h"
+#include "mybfd.h"
 #include "symcat.h"
 #include "nios-desc.h"
 #include "nios-opc.h"

--- a/libr/asm/arch/nios/gnu/nios-opc.h
+++ b/libr/asm/arch/nios/gnu/nios-opc.h
@@ -1,0 +1,180 @@
+/* Instruction opcode header for nios.
+
+THIS FILE IS MACHINE GENERATED WITH CGEN.
+
+Copyright (C) 1996, 1997, 1998, 1999 Free Software Foundation, Inc.
+
+This file is part of the GNU Binutils and/or GDB, the GNU debugger.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#ifndef NIOS_OPC_H
+#define NIOS_OPC_H
+
+/* -- opc.h */
+
+#undef CGEN_DIS_HASH_SIZE
+#define CGEN_DIS_HASH_SIZE 65
+#undef CGEN_DIS_HASH
+#define CGEN_DIS_HASH(buffer, value) (((unsigned char *) (buffer))[1] >> 5)
+
+/* condition code masks for SKPS instruction */
+
+#define CC_C       0x0
+#define CC_NC      0x1
+#define CC_Z       0x2
+#define CC_NZ      0x3
+#define CC_MI      0x4
+#define CC_PL      0x5
+#define CC_GE      0x6
+#define CC_LT      0x7
+#define CC_LE      0x8
+#define CC_GT      0x9
+#define CC_V       0xa
+#define CC_NV      0xb
+#define CC_LS      0xc
+#define CC_HI      0xd
+#define CC_MAX     CC_HI
+
+/* following activates check beyond hashing since m16 and m32 instructions
+ * hash identically, but have different descriptions */
+#define CGEN_VALIDATE_INSN_SUPPORTED
+
+/* following allows reason codes to be output when assembler errors occur */
+#define CGEN_VERBOSE_ASSEMBLER_ERRORS
+
+/* Special check to ensure that instruction exists for given machine */
+static int
+nios_cgen_insn_supported (cd, insn)
+     CGEN_CPU_DESC cd;
+     CGEN_INSN *insn;
+{
+  int machs = cd->machs;
+
+  return ((CGEN_INSN_ATTR_VALUE (insn, CGEN_INSN_MACH) & machs) != 0);
+}
+
+/* values to signal between parse routines and md_assemble */
+extern int nios_parsed_i11;
+extern int nios_Rbi5;
+
+/* values of nios_Rbi5 to help catch Rbi5 syntax errors */
+#define NIOS_RBI5_REGISTER  1
+#define NIOS_RBI5_IMMEDIATE 2
+
+/* -- */
+/* Enum declaration for nios instruction types.  */
+typedef enum cgen_insn_type {
+  NIOS_INSN_INVALID, NIOS_INSN_EXT8S16, NIOS_INSN_ST8S16, NIOS_INSN_STS8S16
+ , NIOS_INSN_ST8D16, NIOS_INSN_WRCTL16, NIOS_INSN_ADDC16, NIOS_INSN_SUBC16
+ , NIOS_INSN_ADD16, NIOS_INSN_SUB16, NIOS_INSN_ADDI16, NIOS_INSN_SUBI16
+ , NIOS_INSN_OR16, NIOS_INSN_XOR16, NIOS_INSN_AND16, NIOS_INSN_ANDN16
+ , NIOS_INSN_LSL16, NIOS_INSN_LSR16, NIOS_INSN_ASR16, NIOS_INSN_LSLI16
+ , NIOS_INSN_LSRI16, NIOS_INSN_ASRI16, NIOS_INSN_NOT16, NIOS_INSN_NEG16
+ , NIOS_INSN_ABS16, NIOS_INSN_MOV16, NIOS_INSN_MOVI16, NIOS_INSN_BGEN16
+ , NIOS_INSN_CMP16, NIOS_INSN_CMPI16,                  NIOS_INSN_EXT8D16
+ , NIOS_INSN_SEXT816, NIOS_INSN_FILL816, NIOS_INSN_LDS16, NIOS_INSN_STS16
+ , NIOS_INSN_LDP16, NIOS_INSN_STP16, NIOS_INSN_LD16, NIOS_INSN_ST16
+ , NIOS_INSN_TRAP16, NIOS_INSN_TRET16, NIOS_INSN_SAVE16, NIOS_INSN_RESTORE16
+ , NIOS_INSN_BSR16, NIOS_INSN_BSRR16, NIOS_INSN_JMP16, NIOS_INSN_CALL16
+ , NIOS_INSN_JMPC16, NIOS_INSN_CALLC16, NIOS_INSN_SKP016, NIOS_INSN_SKP116
+ , NIOS_INSN_SKPRZ16, NIOS_INSN_SKPRNZ16, NIOS_INSN_SKPS16, NIOS_INSN_RRC16
+ , NIOS_INSN_RLC16, NIOS_INSN_RDCTL16, NIOS_INSN_USR016, NIOS_INSN_USR116
+ , NIOS_INSN_USR216, NIOS_INSN_USR316, NIOS_INSN_USR416, NIOS_INSN_STS8S32
+ , NIOS_INSN_STS16S, NIOS_INSN_MOVHI, NIOS_INSN_EXT16D, NIOS_INSN_SEXT16
+ , NIOS_INSN_ST16D, NIOS_INSN_FILL16, NIOS_INSN_EXT8S32, NIOS_INSN_ST8S32
+ , NIOS_INSN_EXT16S, NIOS_INSN_ST16S, NIOS_INSN_ST8D32, NIOS_INSN_WRCTL32 
+ , NIOS_INSN_ADD32, NIOS_INSN_SUB32, NIOS_INSN_ADDI32, NIOS_INSN_SUBI32
+ , NIOS_INSN_OR32, NIOS_INSN_XOR32, NIOS_INSN_AND32, NIOS_INSN_ANDN32
+ , NIOS_INSN_LSL32, NIOS_INSN_LSR32, NIOS_INSN_ASR32, NIOS_INSN_LSLI32
+ , NIOS_INSN_LSRI32, NIOS_INSN_ASRI32, NIOS_INSN_NOT32, NIOS_INSN_NEG32
+ , NIOS_INSN_ABS32, NIOS_INSN_MOV32, NIOS_INSN_MOVI32, NIOS_INSN_BGEN32
+ , NIOS_INSN_CMP32, NIOS_INSN_CMPI32,                  NIOS_INSN_EXT8D32
+ , NIOS_INSN_SEXT832, NIOS_INSN_FILL832, NIOS_INSN_LDS32, NIOS_INSN_STS32
+ , NIOS_INSN_LDP32, NIOS_INSN_STP32, NIOS_INSN_LD32, NIOS_INSN_ST32
+ , NIOS_INSN_TRAP32, NIOS_INSN_TRET32, NIOS_INSN_SAVE32, NIOS_INSN_RESTORE32
+ , NIOS_INSN_BSR32, NIOS_INSN_BSRR32, NIOS_INSN_JMP32, NIOS_INSN_CALL32
+ , NIOS_INSN_JMPC32, NIOS_INSN_CALLC32, NIOS_INSN_SKP032, NIOS_INSN_SKP132
+ , NIOS_INSN_SKPRZ32, NIOS_INSN_SKPRNZ32, NIOS_INSN_SKPS32, NIOS_INSN_RRC32
+ , NIOS_INSN_RLC32, NIOS_INSN_RDCTL32, NIOS_INSN_PFX, NIOS_INSN_BR
+ , NIOS_INSN_SWAP32, NIOS_INSN_MSTEP32, NIOS_INSN_MUL32, NIOS_INSN_USR032
+ , NIOS_INSN_USR132, NIOS_INSN_USR232, NIOS_INSN_USR332, NIOS_INSN_USR432
+ , NIOS_INSN_PFXIO, NIOS_INSN_MAX
+} CGEN_INSN_TYPE;
+
+/* Index of `invalid' insn place holder.  */
+#define CGEN_INSN_INVALID NIOS_INSN_INVALID
+
+/* Total number of insns in table.  */
+#define MAX_INSNS ((int) NIOS_INSN_MAX)
+
+/* This struct records data prior to insertion or after extraction.  */
+struct cgen_fields
+{
+  int length;
+  long f_nil;
+  long f_anyof;
+  long f_op6;
+  long f_op3;
+  long f_op4;
+  long f_op5;
+  long f_op5_hi;
+  long f_op8;
+  long f_op9;
+  long f_op11;
+  long f_Ra;
+  long f_Rb;
+  long f_Rbi5;
+  long f_Rz;
+  long f_Rp;
+  long f_CTLc;
+  long f_i2;
+  long f_i4w;
+  long f_x1;
+  long f_o1;
+  long f_o2;
+  long f_i5;
+  long f_i6v;
+  long f_i8;
+  long f_i8v;
+  long f_i9;
+  long f_i10;
+  long f_i11;
+  long f_i6_rel_h;
+  long f_i6_rel_w;
+  long f_bsrr_i6_rel;
+  long f_i8v_rel_h;
+  long f_i8v_rel_w;
+  long f_i11_rel;
+  long f_i1;
+};
+
+#define CGEN_INIT_PARSE(od) \
+{\
+}
+#define CGEN_INIT_INSERT(od) \
+{\
+}
+#define CGEN_INIT_EXTRACT(od) \
+{\
+}
+#define CGEN_INIT_PRINT(od) \
+{\
+}
+
+
+#endif /* NIOS_OPC_H */

--- a/libr/asm/arch/nios/gnu/nios-opc.h
+++ b/libr/asm/arch/nios/gnu/nios-opc.h
@@ -2,28 +2,32 @@
 
 THIS FILE IS MACHINE GENERATED WITH CGEN.
 
-Copyright (C) 1996, 1997, 1998, 1999 Free Software Foundation, Inc.
+Copyright (C) 1996-2018 Free Software Foundation, Inc.
 
 This file is part of the GNU Binutils and/or GDB, the GNU debugger.
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2, or (at your option)
-any later version.
+   This file is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3, or (at your option)
+   any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+   It is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+   License for more details.
 
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.
 
 */
 
 #ifndef NIOS_OPC_H
 #define NIOS_OPC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* -- opc.h */
 
@@ -58,10 +62,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define CGEN_VERBOSE_ASSEMBLER_ERRORS
 
 /* Special check to ensure that instruction exists for given machine */
-static int
-nios_cgen_insn_supported (cd, insn)
-     CGEN_CPU_DESC cd;
-     CGEN_INSN *insn;
+ATTRIBUTE_UNUSED static int
+nios_cgen_insn_supported (CGEN_CPU_DESC cd, const CGEN_INSN *insn)
 {
   int machs = cd->machs;
 
@@ -176,5 +178,9 @@ struct cgen_fields
 {\
 }
 
+
+   #ifdef __cplusplus
+   }
+   #endif
 
 #endif /* NIOS_OPC_H */

--- a/libr/asm/arch/nios/gnu/safe-ctype.c
+++ b/libr/asm/arch/nios/gnu/safe-ctype.c
@@ -1,0 +1,254 @@
+/* <ctype.h> replacement macros.
+
+   Copyright (C) 2000-2018 Free Software Foundation, Inc.
+   Contributed by Zack Weinberg <zackw@stanford.edu>.
+
+This file is part of the libiberty library.
+Libiberty is free software; you can redistribute it and/or
+modify it under the terms of the GNU Library General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+Libiberty is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public
+License along with libiberty; see the file COPYING.LIB.  If
+not, write to the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+Boston, MA 02110-1301, USA.  */
+
+/*
+
+@defvr Extension HOST_CHARSET
+This macro indicates the basic character set and encoding used by the
+host: more precisely, the encoding used for character constants in
+preprocessor @samp{#if} statements (the C "execution character set").
+It is defined by @file{safe-ctype.h}, and will be an integer constant
+with one of the following values:
+
+@ftable @code
+@item HOST_CHARSET_UNKNOWN
+The host character set is unknown - that is, not one of the next two
+possibilities.
+
+@item HOST_CHARSET_ASCII
+The host character set is ASCII.
+
+@item HOST_CHARSET_EBCDIC
+The host character set is some variant of EBCDIC.  (Only one of the
+nineteen EBCDIC varying characters is tested; exercise caution.)
+@end ftable
+@end defvr
+
+@deffn  Extension ISALPHA  (@var{c})
+@deffnx Extension ISALNUM  (@var{c})
+@deffnx Extension ISBLANK  (@var{c})
+@deffnx Extension ISCNTRL  (@var{c})
+@deffnx Extension ISDIGIT  (@var{c})
+@deffnx Extension ISGRAPH  (@var{c})
+@deffnx Extension ISLOWER  (@var{c})
+@deffnx Extension ISPRINT  (@var{c})
+@deffnx Extension ISPUNCT  (@var{c})
+@deffnx Extension ISSPACE  (@var{c})
+@deffnx Extension ISUPPER  (@var{c})
+@deffnx Extension ISXDIGIT (@var{c})
+
+These twelve macros are defined by @file{safe-ctype.h}.  Each has the
+same meaning as the corresponding macro (with name in lowercase)
+defined by the standard header @file{ctype.h}.  For example,
+@code{ISALPHA} returns true for alphabetic characters and false for
+others.  However, there are two differences between these macros and
+those provided by @file{ctype.h}:
+
+@itemize @bullet
+@item These macros are guaranteed to have well-defined behavior for all 
+values representable by @code{signed char} and @code{unsigned char}, and
+for @code{EOF}.
+
+@item These macros ignore the current locale; they are true for these
+fixed sets of characters:
+@multitable {@code{XDIGIT}} {yada yada yada yada yada yada yada yada}
+@item @code{ALPHA}  @tab @kbd{A-Za-z}
+@item @code{ALNUM}  @tab @kbd{A-Za-z0-9}
+@item @code{BLANK}  @tab @kbd{space tab}
+@item @code{CNTRL}  @tab @code{!PRINT}
+@item @code{DIGIT}  @tab @kbd{0-9}
+@item @code{GRAPH}  @tab @code{ALNUM || PUNCT}
+@item @code{LOWER}  @tab @kbd{a-z}
+@item @code{PRINT}  @tab @code{GRAPH ||} @kbd{space}
+@item @code{PUNCT}  @tab @kbd{`~!@@#$%^&*()_-=+[@{]@}\|;:'",<.>/?}
+@item @code{SPACE}  @tab @kbd{space tab \n \r \f \v}
+@item @code{UPPER}  @tab @kbd{A-Z}
+@item @code{XDIGIT} @tab @kbd{0-9A-Fa-f}
+@end multitable
+
+Note that, if the host character set is ASCII or a superset thereof,
+all these macros will return false for all values of @code{char} outside
+the range of 7-bit ASCII.  In particular, both ISPRINT and ISCNTRL return
+false for characters with numeric values from 128 to 255.
+@end itemize
+@end deffn
+
+@deffn  Extension ISIDNUM         (@var{c})
+@deffnx Extension ISIDST          (@var{c})
+@deffnx Extension IS_VSPACE       (@var{c})
+@deffnx Extension IS_NVSPACE      (@var{c})
+@deffnx Extension IS_SPACE_OR_NUL (@var{c})
+@deffnx Extension IS_ISOBASIC     (@var{c})
+These six macros are defined by @file{safe-ctype.h} and provide
+additional character classes which are useful when doing lexical
+analysis of C or similar languages.  They are true for the following
+sets of characters:
+
+@multitable {@code{SPACE_OR_NUL}} {yada yada yada yada yada yada yada yada}
+@item @code{IDNUM}        @tab @kbd{A-Za-z0-9_}
+@item @code{IDST}         @tab @kbd{A-Za-z_}
+@item @code{VSPACE}       @tab @kbd{\r \n}
+@item @code{NVSPACE}      @tab @kbd{space tab \f \v \0}
+@item @code{SPACE_OR_NUL} @tab @code{VSPACE || NVSPACE}
+@item @code{ISOBASIC}     @tab @code{VSPACE || NVSPACE || PRINT}
+@end multitable
+@end deffn
+
+*/
+
+#include "ansidecl.h"
+#include <safe-ctype.h>
+#include <stdio.h>  /* for EOF */
+
+#if EOF != -1
+ #error "<safe-ctype.h> requires EOF == -1"
+#endif
+
+/* Shorthand */
+#define bl _sch_isblank
+#define cn _sch_iscntrl
+#define di _sch_isdigit
+#define is _sch_isidst
+#define lo _sch_islower
+#define nv _sch_isnvsp
+#define pn _sch_ispunct
+#define pr _sch_isprint
+#define sp _sch_isspace
+#define up _sch_isupper
+#define vs _sch_isvsp
+#define xd _sch_isxdigit
+
+/* Masks.  */
+#define L  (const unsigned short) (lo|is   |pr)	/* lower case letter */
+#define XL (const unsigned short) (lo|is|xd|pr)	/* lowercase hex digit */
+#define U  (const unsigned short) (up|is   |pr)	/* upper case letter */
+#define XU (const unsigned short) (up|is|xd|pr)	/* uppercase hex digit */
+#define D  (const unsigned short) (di   |xd|pr)	/* decimal digit */
+#define P  (const unsigned short) (pn      |pr)	/* punctuation */
+#define _  (const unsigned short) (pn|is   |pr)	/* underscore */
+
+#define C  (const unsigned short) (         cn)	/* control character */
+#define Z  (const unsigned short) (nv      |cn)	/* NUL */
+#define M  (const unsigned short) (nv|sp   |cn)	/* cursor movement: \f \v */
+#define V  (const unsigned short) (vs|sp   |cn)	/* vertical space: \r \n */
+#define T  (const unsigned short) (nv|sp|bl|cn)	/* tab */
+#define S  (const unsigned short) (nv|sp|bl|pr)	/* space */
+
+/* Are we ASCII? */
+#if HOST_CHARSET == HOST_CHARSET_ASCII
+
+const unsigned short _sch_istable[256] =
+{
+  Z,  C,  C,  C,   C,  C,  C,  C,   /* NUL SOH STX ETX  EOT ENQ ACK BEL */
+  C,  T,  V,  M,   M,  V,  C,  C,   /* BS  HT  LF  VT   FF  CR  SO  SI  */
+  C,  C,  C,  C,   C,  C,  C,  C,   /* DLE DC1 DC2 DC3  DC4 NAK SYN ETB */
+  C,  C,  C,  C,   C,  C,  C,  C,   /* CAN EM  SUB ESC  FS  GS  RS  US  */
+  S,  P,  P,  P,   P,  P,  P,  P,   /* SP  !   "   #    $   %   &   '   */
+  P,  P,  P,  P,   P,  P,  P,  P,   /* (   )   *   +    ,   -   .   /   */
+  D,  D,  D,  D,   D,  D,  D,  D,   /* 0   1   2   3    4   5   6   7   */
+  D,  D,  P,  P,   P,  P,  P,  P,   /* 8   9   :   ;    <   =   >   ?   */
+  P, XU, XU, XU,  XU, XU, XU,  U,   /* @   A   B   C    D   E   F   G   */
+  U,  U,  U,  U,   U,  U,  U,  U,   /* H   I   J   K    L   M   N   O   */
+  U,  U,  U,  U,   U,  U,  U,  U,   /* P   Q   R   S    T   U   V   W   */
+  U,  U,  U,  P,   P,  P,  P,  _,   /* X   Y   Z   [    \   ]   ^   _   */
+  P, XL, XL, XL,  XL, XL, XL,  L,   /* `   a   b   c    d   e   f   g   */
+  L,  L,  L,  L,   L,  L,  L,  L,   /* h   i   j   k    l   m   n   o   */
+  L,  L,  L,  L,   L,  L,  L,  L,   /* p   q   r   s    t   u   v   w   */
+  L,  L,  L,  P,   P,  P,  P,  C,   /* x   y   z   {    |   }   ~   DEL */
+
+  /* high half of unsigned char is locale-specific, so all tests are
+     false in "C" locale */
+  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,
+  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,
+  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,
+  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,
+
+  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,
+  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,
+  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,
+  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,
+};
+
+const unsigned char _sch_tolower[256] =
+{
+   0,  1,  2,  3,   4,  5,  6,  7,   8,  9, 10, 11,  12, 13, 14, 15,
+  16, 17, 18, 19,  20, 21, 22, 23,  24, 25, 26, 27,  28, 29, 30, 31,
+  32, 33, 34, 35,  36, 37, 38, 39,  40, 41, 42, 43,  44, 45, 46, 47,
+  48, 49, 50, 51,  52, 53, 54, 55,  56, 57, 58, 59,  60, 61, 62, 63,
+  64,
+
+  'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+  'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+
+  91, 92, 93, 94, 95, 96,
+
+  'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+  'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+
+ 123,124,125,126,127,
+
+ 128,129,130,131, 132,133,134,135, 136,137,138,139, 140,141,142,143,
+ 144,145,146,147, 148,149,150,151, 152,153,154,155, 156,157,158,159,
+ 160,161,162,163, 164,165,166,167, 168,169,170,171, 172,173,174,175,
+ 176,177,178,179, 180,181,182,183, 184,185,186,187, 188,189,190,191,
+
+ 192,193,194,195, 196,197,198,199, 200,201,202,203, 204,205,206,207,
+ 208,209,210,211, 212,213,214,215, 216,217,218,219, 220,221,222,223,
+ 224,225,226,227, 228,229,230,231, 232,233,234,235, 236,237,238,239,
+ 240,241,242,243, 244,245,246,247, 248,249,250,251, 252,253,254,255,
+};
+
+const unsigned char _sch_toupper[256] =
+{
+   0,  1,  2,  3,   4,  5,  6,  7,   8,  9, 10, 11,  12, 13, 14, 15,
+  16, 17, 18, 19,  20, 21, 22, 23,  24, 25, 26, 27,  28, 29, 30, 31,
+  32, 33, 34, 35,  36, 37, 38, 39,  40, 41, 42, 43,  44, 45, 46, 47,
+  48, 49, 50, 51,  52, 53, 54, 55,  56, 57, 58, 59,  60, 61, 62, 63,
+  64,
+
+  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+  'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+
+  91, 92, 93, 94, 95, 96,
+
+  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+  'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+
+ 123,124,125,126,127,
+
+ 128,129,130,131, 132,133,134,135, 136,137,138,139, 140,141,142,143,
+ 144,145,146,147, 148,149,150,151, 152,153,154,155, 156,157,158,159,
+ 160,161,162,163, 164,165,166,167, 168,169,170,171, 172,173,174,175,
+ 176,177,178,179, 180,181,182,183, 184,185,186,187, 188,189,190,191,
+
+ 192,193,194,195, 196,197,198,199, 200,201,202,203, 204,205,206,207,
+ 208,209,210,211, 212,213,214,215, 216,217,218,219, 220,221,222,223,
+ 224,225,226,227, 228,229,230,231, 232,233,234,235, 236,237,238,239,
+ 240,241,242,243, 244,245,246,247, 248,249,250,251, 252,253,254,255,
+};
+
+#else
+# if HOST_CHARSET == HOST_CHARSET_EBCDIC
+  #error "FIXME: write tables for EBCDIC"
+# else
+  #error "Unrecognized host character set"
+# endif
+#endif

--- a/libr/asm/p/Makefile
+++ b/libr/asm/p/Makefile
@@ -10,6 +10,7 @@ ARCHS+=m68k_net.mk
 ARCHS+=blackfin.mk
 ARCHS+=x86_bea.mk
 ARCHS+=msil.mk
+ARCHS+=nios.mk
 ARCHS+=swf.mk
 ARCHS+=vc4.mk
 ARCHS+=mc6809.mk

--- a/libr/asm/p/asm_nios.c
+++ b/libr/asm/p/asm_nios.c
@@ -1,0 +1,24 @@
+/* nios plugin by hewittc at 2018 */
+
+#include <r_asm.h>
+#include <r_lib.h>
+
+static int disassemble (RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
+	return 1;
+}
+
+RAsmPlugin r_asm_plugin_nios = {
+	.name = "nios",
+	.arch = "nios",
+	.license = "GPL3",
+	.bits = 16,
+	.desc = "Nios disassembler",
+	.disassemble = &disassemble,
+};
+
+#ifndef CORELIB
+RLibStruct radare_plugin = {
+	.type = R_LIB_TYPE_ASM,
+	.data = &r_asm_plugin_nios
+};
+#endif

--- a/libr/asm/p/nios.mk
+++ b/libr/asm/p/nios.mk
@@ -1,0 +1,15 @@
+OBJ_NIOS=asm_nios.o
+OBJ_NIOS+=../arch/nios/gnu/nios-dis.o
+OBJ_NIOS+=../arch/nios/gnu/nios-asm.o
+OBJ_NIOS+=../arch/nios/gnu/nios-desc.o
+OBJ_NIOS+=../arch/nios/gnu/nios-ibld.o
+OBJ_NIOS+=../arch/nios/gnu/nios-opc.o
+
+CFLAGS+=-Iarch/include/
+STATIC_OBJ+=${OBJ_NIOS}
+TARGET_NIOS=asm_nios.${LIBEXT}
+
+ALL_TARGETS+=${TARGET_NIOS}
+
+${TARGET_NIOS}: ${OBJ_NIOS}
+	${CC} $(call libname,asm_nios) ${LDFLAGS} ${CFLAGS} -o asm_nios.${LIBEXT} ${OBJ_NIOS}

--- a/libr/asm/p/nios.mk
+++ b/libr/asm/p/nios.mk
@@ -1,15 +1,22 @@
 OBJ_NIOS=asm_nios.o
+
+OBJ_NIOS+=../arch/nios/gnu/safe-ctype.o
+OBJ_NIOS+=../arch/nios/gnu/cgen-bitset.o
+OBJ_NIOS+=../arch/nios/gnu/cgen-dis.o
+OBJ_NIOS+=../arch/nios/gnu/cgen-asm.o
+OBJ_NIOS+=../arch/nios/gnu/cgen-opc.o
+OBJ_NIOS+=../arch/nios/gnu/cpu-nios.o
 OBJ_NIOS+=../arch/nios/gnu/nios-dis.o
 OBJ_NIOS+=../arch/nios/gnu/nios-asm.o
 OBJ_NIOS+=../arch/nios/gnu/nios-desc.o
 OBJ_NIOS+=../arch/nios/gnu/nios-ibld.o
 OBJ_NIOS+=../arch/nios/gnu/nios-opc.o
 
-CFLAGS+=-Iarch/include/
 STATIC_OBJ+=${OBJ_NIOS}
 TARGET_NIOS=asm_nios.${LIBEXT}
 
 ALL_TARGETS+=${TARGET_NIOS}
 
 ${TARGET_NIOS}: ${OBJ_NIOS}
-	${CC} $(call libname,asm_nios) ${LDFLAGS} ${CFLAGS} -o asm_nios.${LIBEXT} ${OBJ_NIOS}
+	${CC} $(call libname,asm_nios) ${LDFLAGS} ${CFLAGS} \
+		-o asm_nios.${LIBEXT} ${OBJ_NIOS}


### PR DESCRIPTION
Hello,

Here is my disassembler plugin targetting the Altera Nios embedded soft processor. It is based on GNUPro Nios CDK 3.1 from https://sourceforge.net/projects/cdk4nios/ and supports nios16 and nios32 machs. Many changes from modern binutils were manually merged in to assist with targetting modern compilers.

Tested with nios32 test file: http://www.jk1mly.org/electoronics/nios/tcsc/NioSyst/cpu_sdk/src/hello_world.out
Compared with original objdump: http://www.jk1mly.org/electoronics/nios/tcsc/NioSyst/cpu_sdk/src/hello_world.objdump

Edit: Forgot about r2pm, so I will work on that now.