### PR TITLE
Fixes long push operands display

### DIFF
--- a/libr/asm/arch/evm/evm.c
+++ b/libr/asm/arch/evm/evm.c
@@ -149,12 +149,12 @@ int evm_dis(EvmOp *op, const unsigned char *buf, int buf_len) {
 	case EVM_OP_PUSH32:
 	{
 		int i, pushSize = buf[0] - EVM_OP_PUSH1;
-		op->imm = 0;
-		for (i = 0; i < pushSize + 1; i++) {
-			op->imm <<= 8;
-			op->imm |= buf[i + 1];
+		char hexbuf[64] = {0};
+		char *hexbufptr = hexbuf;
+		for (i = 0; i < pushSize + 1 && hexbufptr - hexbuf < 62; i++) {
+			hexbufptr += sprintf(hexbufptr, "%02x", buf[i + 1]);
 		}
-		settxtf (op, "push%d 0x%x", pushSize + 1, op->imm);
+		settxtf (op, "push%d 0x%s", pushSize + 1, hexbuf);
 		op->len = 2 + pushSize;
 	}
 	break;

--- a/libr/asm/arch/evm/evm.c
+++ b/libr/asm/arch/evm/evm.c
@@ -148,12 +148,9 @@ int evm_dis(EvmOp *op, const unsigned char *buf, int buf_len) {
 	case EVM_OP_PUSH31:
 	case EVM_OP_PUSH32:
 	{
-		int i, pushSize = buf[0] - EVM_OP_PUSH1;
+		int pushSize = buf[0] - EVM_OP_PUSH1;
 		char hexbuf[64] = {0};
-		char *hexbufptr = hexbuf;
-		for (i = 0; i < pushSize + 1 && hexbufptr - hexbuf < 62; i++) {
-			hexbufptr += sprintf(hexbufptr, "%02x", buf[i + 1]);
-		}
+		r_hex_bin2str(buf + 1, pushSize, hexbuf);
 		settxtf (op, "push%d 0x%s", pushSize + 1, hexbuf);
 		op->len = 2 + pushSize;
 	}

--- a/libr/asm/arch/evm/evm.h
+++ b/libr/asm/arch/evm/evm.h
@@ -150,7 +150,6 @@ typedef enum {
 typedef struct EvmOp {
 	EvmOpcodes op;
 	int len;
-	uint64_t imm;
 	const char *txt;
 	char txt_buf[32];
 } EvmOp;


### PR DESCRIPTION
```
            0x0000007d      65627a7a7230.  push6 0x627a7a723058
            0x00000084      20             sha3
            0x00000085      19             not
            0x00000086      19             invalid
            0x00000087      40             blockhash
            0x00000088      40             invalid
            0x00000089      6626e7d13b32.  push7 0x26e7d13b32b77d
            0x00000091      99             swap10
            0x00000092      648519bde7b1   push5 0x8519bde7b1


```