### PR TITLE
fixes trimmed last bytes in disassembly

### DIFF
--- a/libr/asm/arch/evm/evm.c
+++ b/libr/asm/arch/evm/evm.c
@@ -150,7 +150,7 @@ int evm_dis(EvmOp *op, const unsigned char *buf, int buf_len) {
 	{
 		int pushSize = buf[0] - EVM_OP_PUSH1;
 		char hexbuf[64] = {0};
-		int res = r_hex_bin2str (buf + 1, pushSize, hexbuf);
+		int res = r_hex_bin2str (buf + 1, pushSize + 1, hexbuf);
 		if (res < 1 || !*hexbuf) {
 			strcpy (hexbuf, "0");
 		}


### PR DESCRIPTION
Fixes #194 

```
┌ (fcn) fcn.00000000 14
│   fcn.00000000 ();
│           0x00000000      6080           push1 0x80
│           0x00000002      6040           push1 0x40
│           0x00000004      52             mstore
│           0x00000005      6004           push1 0x04
│           0x00000007      36             calldatasize
│           0x00000008      10             lt
│           0x00000009      610195         push2 0x0195
│           0x0000000c      57             jumpi
└           0x0000000d      63ffffffff     push4 0xffffffff
            0x00000012      7c0100000000.  push29 0x0100000000000000000000
            0x00000030      6000           push1 0x00
            0x00000032      35             calldataload
            0x00000033      04             div
            0x00000034      16             and
            0x00000035      6305514a3e     push4 0x05514a3e
            0x0000003a      81             dup2

```

But I have no idea about the wrong displaying of the long operand in `push29`