### PR TITLE
Update <mybfd.h> to reflect the static inlining of bfd_get_bits

### DIFF
--- a/libr/asm/arch/include/mybfd.h
+++ b/libr/asm/arch/include/mybfd.h
@@ -571,7 +571,29 @@ void bfd_putl16 (bfd_vma, void *);
 
 /* Byte swapping routines which take size and endiannes as arguments.  */
 
-bfd_uint64_t bfd_get_bits (const void *, int, bfd_boolean);
+//bfd_uint64_t bfd_get_bits (const void *, int, bfd_boolean);
+static inline bfd_uint64_t
+bfd_get_bits (const void *p, int bits, bfd_boolean big_p)
+{
+  const bfd_byte *addr = (const bfd_byte *) p;
+  bfd_uint64_t data;
+  int i;
+  int bytes;
+
+  if (bits % 8 != 0)
+    return 0;
+
+  data = 0;
+  bytes = bits / 8;
+  for (i = 0; i < bytes; i++)
+    {
+      int addr_index = big_p ? i : bytes - i - 1;
+
+      data = (data << 8) | addr[addr_index];
+    }
+
+  return data;
+}
 void bfd_put_bits (bfd_uint64_t, void *, int, bfd_boolean);
 
 extern bfd_boolean bfd_section_already_linked_table_init (void);


### PR DESCRIPTION
https://github.com/radare/radare2/blob/master/libr/asm/arch/include/mybfd.h#L584-L585

Fixes building `vc4`, and possibly others